### PR TITLE
[IDLE-35] 프로젝트 CI구축(test project when merge to develop)

### DIFF
--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -27,13 +27,24 @@ jobs:
         with:
           path: /usr/local/bin/tuist
           key: ${{ runner.os }}-tuist@${{ env.TUIST_VERSION }}
-
+    
       #3. install tuist
       - name: install tuist
         if: steps.cache-tuist.outputs.cache-hit != 'true'
         run: |
           mise install tuist@${{ env.TUIST_VERSION }}
           mise use -g tuist@${{ env.TUIST_VERSION }}
+
+      - name: cache tree
+        id: cache-tree
+        uses: actions/cache@v4
+        with:
+          path: /opt/homebrew/bin/tree
+          key: ${{ runner.os }}-tree
+          
+      - name: install tree
+        if: steps.cache-tree.outputs.cache-hit != 'true'
+        run: brew install tree
       
       #4. checkout tuist project repository
       - name: checkout project

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -35,16 +35,22 @@ jobs:
           mise install tuist@${{ env.TUIST_VERSION }}
           mise use -g tuist@${{ env.TUIST_VERSION }}
 
-      - name: cache tree
-        id: cache-tree
-        uses: actions/cache@v4
-        with:
-          path: /opt/homebrew/bin/tree
-          key: ${{ runner.os }}-tree
+      # - name: cache tree
+      #   id: cache-tree
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: /opt/homebrew/bin/tree
+      #     key: ${{ runner.os }}-tree
           
       - name: install tree
-        if: steps.cache-tree.outputs.cache-hit != 'true'
+        # if: steps.cache-tree.outputs.cache-hit != 'true'
         run: brew install tree
+
+      - name: check paths
+        run: |
+          which tuist
+          which tree
+        
       
       #4. checkout tuist project repository
       - name: checkout project

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -60,7 +60,7 @@ jobs:
       
       - run: |
           echo "Checking configurations are loaded..."
-          tree project/XcodeConfiguration
+          tree $GITHUB_WORKSPACE/project/XcodeConfiguration
       
       #6. test tuist project
       - name: Test project

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -64,7 +64,7 @@ jobs:
       
       #6. test tuist project
       - name: Test project
-        run: 
+        run: |
           cd project
           tuist test
 

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -65,6 +65,7 @@ jobs:
       #6. test tuist project
       - name: Test project
         run: 
+          cd project
           tuist test
 
   

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -33,6 +33,7 @@ jobs:
         if: steps.cache-tuist.outputs.cache-hit != 'true'
         run: |
           mise install tuist@${{ env.TUIST_VERSION }}
+          mise use -g tuist@${{ env.TUIST_VERSION }}
       
       #4. checkout tuist project repository
       - name: checkout project
@@ -45,6 +46,10 @@ jobs:
           repository: ${{ secrets.XCCONFIG_REPO }}
           token: ${{ secrets.XCCONFIG_REPO_TOKEN }}
           path: '$GITHUB_WORKSPACE/project/XcodeConfiguration'
+      
+      - run: |
+          echo "Checking configurations are loaded..."
+          tree project/XcodeConfiguration
       
       #6. test tuist project
       - name: Test project

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: add brew to PATH
         run: |
-          echo "/opt/homebrew/bin" >> ${{ github.path }}
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
 
       - name: check paths
         run: |

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -56,11 +56,11 @@ jobs:
         with:
           repository: ${{ secrets.XCCONFIG_REPO }}
           token: ${{ secrets.XCCONFIG_REPO_TOKEN }}
-          path: '$GITHUB_WORKSPACE/project/XcodeConfiguration'
+          path: '${{ github.workspace }}/project/XcodeConfiguration'
       
       - run: |
           echo "Checking configurations are loaded..."
-          tree $GITHUB_WORKSPACE/project/XcodeConfiguration
+          tree ${{ github.workspace }}/project/XcodeConfiguration
       
       #6. test tuist project
       - name: Test project

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -46,11 +46,14 @@ jobs:
         if: steps.cache-tree.outputs.cache-hit != 'true'
         run: brew install tree
 
+      - name: add brew to PATH
+        run: |
+          echo "/opt/homebrew/bin" >> ${{ github.path }}
+
       - name: check paths
         run: |
-          which tuist
-          which tree
-        
+          echo "tuist in installed in $(which tuist)"
+          echo "tree in installed in $(which tree)"
       
       #4. checkout tuist project repository
       - name: checkout project

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -25,7 +25,7 @@ jobs:
         id: cache-tuist
         uses: actions/cache@v4
         with:
-          path: /usr/local/bin/tuist
+          path: /Users/runner/.local/share/mise/shims/tuist
           key: ${{ runner.os }}-tuist@${{ env.TUIST_VERSION }}
     
       #3. install tuist
@@ -35,15 +35,15 @@ jobs:
           mise install tuist@${{ env.TUIST_VERSION }}
           mise use -g tuist@${{ env.TUIST_VERSION }}
 
-      # - name: cache tree
-      #   id: cache-tree
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: /opt/homebrew/bin/tree
-      #     key: ${{ runner.os }}-tree
+      - name: cache tree
+        id: cache-tree
+        uses: actions/cache@v4
+        with:
+          path: /opt/homebrew/bin/tree
+          key: ${{ runner.os }}-tree
           
       - name: install tree
-        # if: steps.cache-tree.outputs.cache-hit != 'true'
+        if: steps.cache-tree.outputs.cache-hit != 'true'
         run: brew install tree
 
       - name: check paths
@@ -72,6 +72,7 @@ jobs:
       - name: Test project
         run: |
           cd project
+          tuist install
           tuist test
 
   

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -34,21 +34,9 @@ jobs:
         run: |
           mise install tuist@${{ env.TUIST_VERSION }}
           mise use -g tuist@${{ env.TUIST_VERSION }}
-
-      - name: cache tree
-        id: cache-tree
-        uses: actions/cache@v4
-        with:
-          path: /opt/homebrew/bin/tree
-          key: ${{ runner.os }}-tree
           
       - name: install tree
-        if: steps.cache-tree.outputs.cache-hit != 'true'
         run: brew install tree
-
-      - name: add brew to PATH
-        run: |
-          echo "/opt/homebrew/bin" >> $GITHUB_PATH
 
       - name: check paths
         run: |
@@ -66,8 +54,9 @@ jobs:
           repository: ${{ secrets.XCCONFIG_REPO }}
           token: ${{ secrets.XCCONFIG_REPO_TOKEN }}
           path: '${{ github.workspace }}/project/XcodeConfiguration'
-      
-      - run: |
+
+      - name: check xcconfig files
+        run: |
           echo "Checking configurations are loaded..."
           tree ${{ github.workspace }}/project/XcodeConfiguration
       

--- a/.github/workflows/merge_to_develop_on_pr.yml
+++ b/.github/workflows/merge_to_develop_on_pr.yml
@@ -1,0 +1,56 @@
+name: PR to [develop]
+on: 
+  pull_request:
+    branches: [ develop ]
+
+#1. load mise
+#2. cache tuist
+#3. install tuist
+#4. checkout tuist project repository
+#5. fetch XCConfig from repository
+#6. test tuist project
+
+jobs:
+  test:
+    runs-on: macos-latest
+    env: 
+      TUIST_VERSION: 4.12.1
+    steps:
+
+      #1. load mise
+      - uses: jdx/mise-action@v2
+
+      #2. cache tuist
+      - name: cache tuist
+        id: cache-tuist
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/tuist
+          key: ${{ runner.os }}-tuist@${{ env.TUIST_VERSION }}
+
+      #3. install tuist
+      - name: install tuist
+        if: steps.cache-tuist.outputs.cache-hit != 'true'
+        run: |
+          mise install tuist@${{ env.TUIST_VERSION }}
+      
+      #4. checkout tuist project repository
+      - name: checkout project
+        uses: actions/checkout@v4
+      
+      #5. fetch XCConfig from repository
+      - name: fetch xcconfig
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ secrets.XCCONFIG_REPO }}
+          token: ${{ secrets.XCCONFIG_REPO_TOKEN }}
+          path: '$GITHUB_WORKSPACE/project/XcodeConfiguration'
+      
+      #6. test tuist project
+      - name: Test project
+        run: 
+          tuist test
+
+  
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore all xcconfig files in all directories
 **/*.xcconfig
+XcodeConfiguration/
 
 # Ignore Derived
 **/Derived/


### PR DESCRIPTION
## 1. 관련된 이슈 및 소개

develop브렌치로 병합전 레포지토리의 Tuist 프로젝트를 test합니다.

## 2. 알게된 점

- simulator를 이용한 test action에는 Certificate와 Provisioning profile이 필요하지 않습니다.
- 노출에 민감한 정보는 Private브렌치에 저장하고 Github Action의 워크플로우 내에서 특정 파일을 불러올 수 있습니다.
- github secrets를 사용하여 민감한 정보를 불어올 수 있는 데이터를 보관할 수 있습니다.