### PR TITLE
[IDLE-123] 센터장 로그인 및 회원가입 네비게이션 구현

### DIFF
--- a/project/Projects/App/Sources/RootCoordinator/Auth/AgencyAuthCoorinator.swift
+++ b/project/Projects/App/Sources/RootCoordinator/Auth/AgencyAuthCoorinator.swift
@@ -1,0 +1,86 @@
+//
+//  AgencyAuthCoorinator.swift
+//  Idle-iOS
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import PresentationCore
+import AuthFeature
+
+class AgencyAuthCoorinator: ParentCoordinator {
+    
+    var childCoordinators: [Coordinator] = []
+    
+    var navigationController: UINavigationController
+    
+    var parent: AuthCoordinatable?
+    
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    deinit { printIfDebug("deinit \(Self.self)") }
+    
+    func start() {
+        
+        let coordinator = AgencyAuthMainCoordinator(
+            navigationController: navigationController
+        )
+        
+        coordinator.parent = self
+        addChildCoordinator(coordinator)
+        
+        coordinator.start()
+    }
+}
+
+extension AgencyAuthCoorinator: AgencyAuthCoordinatable {
+    
+    func login() {
+        
+        let coordinator = AgencyLoginCoordinator(
+            navigationController: navigationController
+        )
+        
+        coordinator.parent = self
+        addChildCoordinator(coordinator)
+        
+        coordinator.start()
+    }
+    
+    func findPassword() {
+        
+        let coordinator = AgencyFindPasswordCoordinator(
+            navigationController: navigationController
+        )
+        
+        coordinator.parent = self
+        addChildCoordinator(coordinator)
+        
+        coordinator.start()
+    }
+    
+    func setNewPassword() {
+        
+        let coordinator = AgencySetNewPasswordCoordinator(
+            navigationController: navigationController
+        )
+        
+        coordinator.parent = self
+        addChildCoordinator(coordinator)
+        
+        coordinator.start()
+    }
+    
+    func register() {
+        
+        
+    }
+    
+    func authFinished() {
+        
+        parent?.authFinished()
+    }
+}

--- a/project/Projects/App/Sources/RootCoordinator/Auth/AgencyAuthCoorinator.swift
+++ b/project/Projects/App/Sources/RootCoordinator/Auth/AgencyAuthCoorinator.swift
@@ -76,7 +76,15 @@ extension AgencyAuthCoorinator: AgencyAuthCoordinatable {
     
     func register() {
         
+        let coordinator = AgencyRegisterCoordinator(
+            navigationController: navigationController
+        )
         
+        coordinator.parent = self
+        
+        addChildCoordinator(coordinator)
+        
+        coordinator.start()
     }
     
     func authFinished() {

--- a/project/Projects/App/Sources/RootCoordinator/Auth/AuthCoordinator+Extension.swift
+++ b/project/Projects/App/Sources/RootCoordinator/Auth/AuthCoordinator+Extension.swift
@@ -24,6 +24,14 @@ extension AuthCoordinator: AuthCoordinatable {
             coordinator.start()
             
         case .agency:
+            
+            let coordinator = AgencyAuthCoorinator(navigationController: navigationController)
+            
+            addChildCoordinator(coordinator)
+            
+            coordinator.parent = self
+            
+            coordinator.start()
             return
         }
     }

--- a/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencyAuthMainCoordinator.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencyAuthMainCoordinator.swift
@@ -1,0 +1,41 @@
+//
+//  AgencyAuthMainCoordinator.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import PresentationCore
+import UIKit
+
+public class AgencyAuthMainCoordinator: ChildCoordinator {
+    
+    public var navigationController: UINavigationController
+    
+    public weak var viewControllerRef: DisposableViewController?
+    
+    public var parent: AgencyAuthCoordinatable?
+    
+    public init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    deinit { printIfDebug("deinit \(Self.self)") }
+    
+    public func coordinatorDidFinish() {
+        
+        viewControllerRef?.cleanUp()
+        
+        parent?.removeChildCoordinator(self)
+    }
+    
+    public func start() {
+        
+        let viewController = AgencyAuthMainViewController()
+        viewController.coordinator = self
+        
+        viewControllerRef = viewController
+        
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencyFindPasswordCoordinator.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencyFindPasswordCoordinator.swift
@@ -1,0 +1,40 @@
+//
+//  AgencyFindPasswordCoordinator.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import PresentationCore
+
+public class AgencyFindPasswordCoordinator: ChildCoordinator {
+    
+    public weak var viewControllerRef: (any PresentationCore.DisposableViewController)?
+    
+    public var navigationController: UINavigationController
+    
+    public var parent: AgencyAuthCoordinatable?
+    
+    public init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    deinit { printIfDebug("deinit \(Self.self)") }
+    
+    public func start() {
+        
+        let viewController = AgencyFindPasswordController()
+        viewController.coordinator = self
+        
+        viewControllerRef = viewController
+        
+        navigationController.pushViewController(viewController, animated: true)
+    }
+    
+    public func coordinatorDidFinish() {
+        
+        popViewController()
+        parent?.removeChildCoordinator(self)
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencyLoginCoordinator.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencyLoginCoordinator.swift
@@ -1,0 +1,40 @@
+//
+//  AgencyLoginCoordinator.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import PresentationCore
+
+public class AgencyLoginCoordinator: ChildCoordinator {
+    
+    public weak var viewControllerRef: (any PresentationCore.DisposableViewController)?
+
+    public var navigationController: UINavigationController
+    
+    public var parent: AgencyAuthCoordinatable?
+    
+    public init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    deinit { printIfDebug("deinit \(Self.self)") }
+    
+    public func start() {
+        
+        let viewController = AgencyLoginViewController()
+        viewController.coordinator = self
+        
+        viewControllerRef = viewController
+        
+        navigationController.pushViewController(viewController, animated: true)
+    }
+    
+    public func coordinatorDidFinish() {
+        
+        popViewController()
+        parent?.removeChildCoordinator(self)
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencyRegisterCoordinator.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencyRegisterCoordinator.swift
@@ -1,0 +1,177 @@
+//
+//  AgencyRegisterCoordinator.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import PresentationCore
+
+enum AgencyRegisterStage: Int {
+    
+    case phoneNumber=0
+    case name=1
+    case businessOwner=2
+    case idPassword=3
+    case finish=4
+    
+    var nextStage: Self? {
+        
+        switch self {
+        case .phoneNumber:
+            return .name
+        case .name:
+            return .businessOwner
+        case .businessOwner:
+            return .idPassword
+        case .idPassword:
+            return .finish
+        default:
+            return nil
+        }
+    }
+}
+
+public class AgencyRegisterCoordinator: ChildCoordinator {
+    
+    public var parent: AgencyAuthCoordinatable?
+    
+    public weak var viewControllerRef: (any PresentationCore.DisposableViewController)?
+    
+    weak var pageViewController: UIPageViewController?
+    
+    public var navigationController: UINavigationController
+    
+    var stageViewControllers: [DisposableViewController] = []
+    
+    private var currentStage: AgencyRegisterStage?
+    
+    public init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    deinit { printIfDebug("deinit \(Self.self)") }
+    
+    public func start() {
+        stageViewControllers = [
+            ValidatePhoneNumberViewController(),
+            EnterNameViewController(),
+            AuthBusinessOwnerViewController(),
+            SetIdPasswordViewController(),
+        ]
+        
+        let pageViewController = UIPageViewController(
+            transitionStyle: .scroll,
+            navigationOrientation: .horizontal,
+            options: nil
+        )
+        
+        self.pageViewController = pageViewController
+        
+        let viewController = AgencyRegisterViewController(
+            pageViewController: pageViewController
+        )
+        
+        viewController.coordinator = self
+        
+        viewControllerRef = viewController
+        
+        navigationController.pushViewController(viewController, animated: true)
+        
+        authPhoneNumber()
+    }
+    
+    public func coordinatorDidFinish() {
+    
+        viewControllerRef?.cleanUp()
+        
+        parent?.removeChildCoordinator(self)
+    }
+}
+
+extension AgencyRegisterCoordinator {
+    
+    func next() {
+        
+        if let nextStage = currentStage?.nextStage {
+            
+            switch nextStage {
+            case .phoneNumber:
+                authPhoneNumber()
+            case .name:
+                enterName()
+            case .businessOwner:
+                authBusinessOwner()
+            case .idPassword:
+                setIdPassword()
+            case .finish:
+                authFinished()
+            default:
+                return
+            }
+        }
+    }
+    
+    func authPhoneNumber() {
+        
+        let viewController = stageViewControllers[AgencyRegisterStage.phoneNumber.rawValue]
+        
+        let phoneStage = viewController as! ValidatePhoneNumberViewController
+        
+        phoneStage.coordinater = self
+        
+        showStage(viewController: phoneStage)
+        
+        currentStage = .phoneNumber
+    }
+    
+    func enterName() {
+        
+        let viewController = stageViewControllers[AgencyRegisterStage.name.rawValue]
+        
+        let nameStage = viewController as! EnterNameViewController
+        
+        nameStage.coordinater = self
+        
+        showStage(viewController: nameStage)
+        
+        currentStage = .name
+    }
+    
+    func authBusinessOwner() {
+        
+        let viewController = stageViewControllers[AgencyRegisterStage.businessOwner.rawValue]
+        
+        let nameStage = viewController as! AuthBusinessOwnerViewController
+        
+        nameStage.coordinater = self
+        
+        showStage(viewController: nameStage)
+        
+        currentStage = .businessOwner
+    }
+    
+    func setIdPassword() {
+        
+        let viewController = stageViewControllers[AgencyRegisterStage.idPassword.rawValue]
+        
+        let nameStage = viewController as! SetIdPasswordViewController
+        
+        nameStage.coordinater = self
+        
+        showStage(viewController: nameStage)
+        
+        currentStage = .idPassword
+    }
+    
+    func showStage(viewController: UIViewController) {
+        
+        pageViewController?.setViewControllers([viewController], direction: .forward, animated: true)
+    }
+    
+    func authFinished() {
+        
+        parent?.authFinished()
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencySetNewPasswordCoordinator.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/Coordinator/Agency/AgencySetNewPasswordCoordinator.swift
@@ -1,0 +1,40 @@
+//
+//  AgencySetNewPasswordCoordinator.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import PresentationCore
+import UIKit
+
+
+public class AgencySetNewPasswordCoordinator: ChildCoordinator {
+    
+    public var navigationController: UINavigationController
+    
+    public weak var viewControllerRef: DisposableViewController?
+    
+    public var parent: AgencyAuthCoordinatable?
+    
+    public init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    deinit { printIfDebug("deinit \(Self.self)") }
+    
+    public func coordinatorDidFinish() {
+        popViewController()
+        parent?.removeChildCoordinator(self)
+    }
+    
+    public func start() {
+        
+        let viewController = AgencySetNewPasswordController()
+        viewController.coordinator = self
+        
+        viewControllerRef = viewController
+        
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/AgencyAuthMainViewController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/AgencyAuthMainViewController.swift
@@ -1,0 +1,67 @@
+//
+//  AgencyAuthMainViewController.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import DSKit
+import PresentationCore
+
+public class AgencyAuthMainViewController: DisposableViewController {
+
+    private lazy var loginButton = ButtonPrototype(text: "로그인") { [weak self] in
+        
+        self?.coordinator?.parent?.login()
+    }
+    
+    private lazy var registerButton = ButtonPrototype(text: "가입하기") { [weak self] in
+        
+        self?.coordinator?.parent?.register()
+    }
+    
+    var coordinator: AgencyAuthMainCoordinator?
+    
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        view.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 20)
+        
+        let title = UILabel()
+        title.text = "센터장으로 시작하기"
+        title.font = .boldSystemFont(ofSize: 24)
+        
+        [
+            title,
+            loginButton,
+            registerButton
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+        
+            // 등록 버튼
+            registerButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            registerButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            registerButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+            
+            // 로그인 버튼
+            loginButton.bottomAnchor.constraint(equalTo: registerButton.topAnchor, constant: -10),
+            loginButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            loginButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+        
+            // 타이틀
+            title.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            title.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+        
+    }
+
+    public func cleanUp() {
+        
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/AgencyFindPasswordController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/AgencyFindPasswordController.swift
@@ -1,0 +1,56 @@
+//
+//  AgencyFindPasswordController.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import DSKit
+import PresentationCore
+
+class AgencyFindPasswordController: DisposableViewController {
+    
+    private lazy var setNewPasswordButton = ButtonPrototype(text: "새로운 비밀번호 설정(임시)") { [weak self] in
+        
+        self?.coordinator?.parent?.setNewPassword()
+    }
+    
+    var coordinator: AgencyFindPasswordCoordinator?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        view.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 20)
+        
+        let title = UILabel()
+        title.text = "비밀번호 찾기/사업자 인증"
+        title.font = .boldSystemFont(ofSize: 24)
+        
+        [
+            title,
+            setNewPasswordButton,
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+        
+        
+        NSLayoutConstraint.activate([
+        
+            // 등록 버튼
+            setNewPasswordButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            setNewPasswordButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            setNewPasswordButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+            
+            // 타이틀
+            title.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            title.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+    }
+    
+    func cleanUp() {
+        
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/AgencyLoginViewController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/AgencyLoginViewController.swift
@@ -1,0 +1,68 @@
+//
+//  AgencyLoginViewController.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import DSKit
+import PresentationCore
+
+class AgencyLoginViewController: DisposableViewController {
+    
+    private lazy var loginButton = ButtonPrototype(text: "로그인(실행)") { [weak self] in
+        
+        // 화면 닫기
+        self?.coordinator?.parent?.authFinished()
+    }
+    
+    private lazy var findPasswordButton = ButtonPrototype(text: "비밀번호 찾기") { [weak self] in
+        
+        self?.coordinator?.parent?.findPassword()
+    }
+    
+    var coordinator: AgencyLoginCoordinator?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        view.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 20)
+        
+        let title = UILabel()
+        title.text = "로그인 화면: 아이디 패스워드 입력"
+        title.font = .boldSystemFont(ofSize: 24)
+        
+        [
+            title,
+            loginButton,
+            findPasswordButton
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+        
+            // 비밀번호 찾기 버튼
+            findPasswordButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            findPasswordButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            findPasswordButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+            
+            // 로그인 버튼
+            loginButton.bottomAnchor.constraint(equalTo: findPasswordButton.topAnchor, constant: -10),
+            loginButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            loginButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+        
+            // 타이틀
+            title.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            title.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+        
+    }
+    
+    func cleanUp() {
+        
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/AgencySetNewPasswordController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/AgencySetNewPasswordController.swift
@@ -1,0 +1,58 @@
+//
+//  AgencySetNewPasswordController.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import DSKit
+import PresentationCore
+
+
+
+class AgencySetNewPasswordController: DisposableViewController {
+    
+    private lazy var setNewPasswordButton = ButtonPrototype(text: "새로운 비밀번호 설정완료") { [weak self] in
+        
+        self?.coordinator?.parent?.authFinished()
+    }
+    
+    var coordinator: AgencySetNewPasswordCoordinator?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        view.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 20)
+        
+        let title = UILabel()
+        title.text = "비밀번호 재설정"
+        title.font = .boldSystemFont(ofSize: 24)
+        
+        [
+            title,
+            setNewPasswordButton,
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+        
+        
+        NSLayoutConstraint.activate([
+        
+            // 등록 버튼
+            setNewPasswordButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            setNewPasswordButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            setNewPasswordButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
+            
+            // 타이틀
+            title.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            title.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ])
+    }
+    
+    func cleanUp() {
+        
+    }
+}

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/Register/AgencyRegisterViewController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/Register/AgencyRegisterViewController.swift
@@ -1,0 +1,74 @@
+//
+//  AgencyRegisterViewController.swift
+//  AuthFeature
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import UIKit
+import DSKit
+import PresentationCore
+
+class AgencyRegisterViewController: DisposableViewController {
+    
+    var coordinator: AgencyRegisterCoordinator?
+    
+    var pageViewController: UIPageViewController
+    
+    lazy var nextButton = ButtonPrototype(text: "다음") { [weak self] in
+        
+        self?.coordinator?.next()
+    }
+    
+    init(pageViewController: UIPageViewController) {
+        
+        self.pageViewController = pageViewController
+        
+        super.init(nibName: nil, bundle: nil)
+        
+        addChild(pageViewController)
+    }
+    
+    required init?(coder: NSCoder) { fatalError() }
+    
+    override func viewDidLoad() {
+        
+        view.backgroundColor = .white
+        
+        let statusView = UILabel()
+        
+        statusView.textColor = .black
+        statusView.text = "스테이터스 바"
+        
+        [
+            statusView,
+            pageViewController.view,
+            nextButton
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            view.addSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+        
+            statusView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            statusView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            statusView.heightAnchor.constraint(equalToConstant: 100),
+            
+            pageViewController.view.topAnchor.constraint(equalTo: statusView.bottomAnchor),
+            pageViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            pageViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pageViewController.view.bottomAnchor.constraint(equalTo: nextButton.topAnchor),
+            
+            nextButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            nextButton.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor, constant: 20),
+            nextButton.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor, constant: -20)
+        ])
+    }
+    
+    func cleanUp() {
+        
+        coordinator?.stageViewControllers = []
+    }
+}
+

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/Register/AuthBusinessOwnerViewController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/Register/AuthBusinessOwnerViewController.swift
@@ -1,23 +1,23 @@
 //
-//  EnterNameViewController.swift
+//  AuthBusinessOwnerViewController.swift
 //  AuthFeature
 //
-//  Created by choijunios on 6/30/24.
+//  Created by choijunios on 7/1/24.
 //
 
 import UIKit
 import PresentationCore
 
-class EnterNameViewController: DisposableViewController {
+class AuthBusinessOwnerViewController: DisposableViewController {
     
-    var coordinater: Coordinator?
+    var coordinater: AgencyRegisterCoordinator?
     
     override func viewDidLoad() {
         
         view.backgroundColor = .white
         
         let label = UILabel()
-        label.text = "이름 입력"
+        label.text = "사업자 인증 화면"
         
         view.addSubview(label)
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/Register/SetIdPasswordViewController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Agency/Register/SetIdPasswordViewController.swift
@@ -1,23 +1,23 @@
 //
-//  EnterNameViewController.swift
+//  SetIdPasswordViewController.swift
 //  AuthFeature
 //
-//  Created by choijunios on 6/30/24.
+//  Created by choijunios on 7/1/24.
 //
 
 import UIKit
 import PresentationCore
 
-class EnterNameViewController: DisposableViewController {
+class SetIdPasswordViewController: DisposableViewController {
     
-    var coordinater: Coordinator?
+    var coordinater: AgencyRegisterCoordinator?
     
     override func viewDidLoad() {
         
         view.backgroundColor = .white
         
         let label = UILabel()
-        label.text = "이름 입력"
+        label.text = "아이디 패스워드 최초 설정화면"
         
         view.addSubview(label)
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Common/Register/ValidatePhoneNumberViewController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Common/Register/ValidatePhoneNumberViewController.swift
@@ -10,7 +10,7 @@ import PresentationCore
 
 class ValidatePhoneNumberViewController: DisposableViewController {
     
-    var coordinater: AgentRegisterCoordinator?
+    var coordinater: Coordinator?
     
     override func viewDidLoad() {
         

--- a/project/Projects/Presentation/PresentationCore/Sources/ScreenCoordinating/Coordinator.swift
+++ b/project/Projects/Presentation/PresentationCore/Sources/ScreenCoordinating/Coordinator.swift
@@ -47,6 +47,8 @@ public extension ParentCoordinator {
     
     func clearChildren() {
         
+        print(self, childCoordinators, navigationController.viewControllers)
+        
         let lastCoordinator = childCoordinators.popLast()
         
         var middleViewControllers: [UIViewController?] = []
@@ -89,6 +91,8 @@ public extension ParentCoordinator {
                 lastCoordinator.popViewController()
             }
         }
+        
+        print("종료", self, childCoordinators, navigationController.viewControllers)
     }
 }
 

--- a/project/Projects/Presentation/PresentationCore/Sources/ScreenCoordinating/Interface/Auth/AgencyAuthCoordinatable.swift
+++ b/project/Projects/Presentation/PresentationCore/Sources/ScreenCoordinating/Interface/Auth/AgencyAuthCoordinatable.swift
@@ -1,0 +1,17 @@
+//
+//  AgencyAuthCoordinatable.swift
+//  PresentationCore
+//
+//  Created by choijunios on 7/1/24.
+//
+
+import Foundation
+
+public protocol AgencyAuthCoordinatable: ParentCoordinator {
+    
+    func login()
+    func findPassword()
+    func setNewPassword()
+    func register()
+    func authFinished()
+}


### PR DESCRIPTION
## 1. 관련된 이슈 및 소개

Coordinator패턴을 사용하여 센터장의 로그인및 회원가입 네비게이션을 구현하였습니다.
Xcode Instruments중 Allocation기능을 사용하여 화면을 껐을 때 Coordinator와 ViewController가 모두 메모리 해제되는 것을 확인하였습니다.

## 2. Instruments-Allocation 테스트 영상

![로그인 회원가입Coordinator 메모리 누수 없음 확인 복사본](https://github.com/3IDLES/idle-iOS/assets/106458638/f3804f5d-ce61-4043-b21c-860001f1b199)

