### PR TITLE
[IDLE-74] 로그인시 토큰 로컬 저장및 모든 요청에 적용

### DIFF
--- a/project/Projects/Data/ConcreteRepository/Auth/DefaultAuthInputValidationRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Auth/DefaultAuthInputValidationRepository.swift
@@ -29,7 +29,7 @@ public class DefaultAuthInputValidationRepository: AuthInputValidationRepository
                 case 204:
                     return .success(true)
                 default:
-                    return .failure(self.decodeError(of: CenterRegisterError.self, data: response.data))
+                    return .failure(self.decodeError(of: InputValidationError.self, data: response.data))
                 }
             }
     }
@@ -46,7 +46,7 @@ public class DefaultAuthInputValidationRepository: AuthInputValidationRepository
                 case 204:
                     return .success(true)
                 default:
-                    return .failure(self.decodeError(of: CenterRegisterError.self, data: response.data))
+                    return .failure(self.decodeError(of: InputValidationError.self, data: response.data))
                 }
             }
     }
@@ -64,7 +64,7 @@ public class DefaultAuthInputValidationRepository: AuthInputValidationRepository
                     let dto: BusinessInfoDTO = self.decodeData(data: response.data)
                     return .success(dto.toEntity())
                 default:
-                    return .failure(self.decodeError(of: CenterRegisterError.self, data: response.data))
+                    return .failure(self.decodeError(of: InputValidationError.self, data: response.data))
                 }
             }
     }
@@ -82,7 +82,7 @@ public class DefaultAuthInputValidationRepository: AuthInputValidationRepository
                 case 400:
                     return .success(false)
                 default:
-                    return .failure(self.decodeError(of: CenterRegisterError.self, data: response.data))
+                    return .failure(self.decodeError(of: InputValidationError.self, data: response.data))
                 }
             }
     }

--- a/project/Projects/Data/ConcreteRepository/Auth/DefaultAuthInputValidationRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Auth/DefaultAuthInputValidationRepository.swift
@@ -13,7 +13,7 @@ import Entity
 
 public class DefaultAuthInputValidationRepository: AuthInputValidationRepository {
     
-    let networkService = CenterRegisterService()
+    let networkService = AuthService()
     
     public init() { }
     

--- a/project/Projects/Data/ConcreteRepository/Auth/DefaultAuthInputValidationRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Auth/DefaultAuthInputValidationRepository.swift
@@ -19,7 +19,7 @@ public class DefaultAuthInputValidationRepository: AuthInputValidationRepository
     
     public func requestPhoneNumberAuthentication(phoneNumber: String) -> RxSwift.Single<BoolResult> {
         
-        networkService.request(api: .startPhoneNumberAuth(phoneNumber: phoneNumber))
+        networkService.requestWithoutToken(api: .startPhoneNumberAuth(phoneNumber: phoneNumber))
             .catch { [weak self] in .error(self?.filterNetworkConnection($0) ?? $0) }
             .map { [weak self] response in
                 
@@ -36,7 +36,7 @@ public class DefaultAuthInputValidationRepository: AuthInputValidationRepository
     
     public func authenticateAuthNumber(phoneNumber: String, authNumber: String) -> RxSwift.Single<BoolResult> {
         
-        networkService.request(api: .checkAuthNumber(phoneNumber: phoneNumber, authNumber: authNumber))
+        networkService.requestWithoutToken(api: .checkAuthNumber(phoneNumber: phoneNumber, authNumber: authNumber))
             .catch { [weak self] in .error(self?.filterNetworkConnection($0) ?? $0) }
             .map { [weak self] response in
                 
@@ -53,7 +53,7 @@ public class DefaultAuthInputValidationRepository: AuthInputValidationRepository
     
     public func requestBusinessNumberAuthentication(businessNumber: String) -> RxSwift.Single<BusinessNumberAuthResult> {
         
-        networkService.request(api: .authenticateBusinessNumber(businessNumber: businessNumber))
+        networkService.requestWithoutToken(api: .authenticateBusinessNumber(businessNumber: businessNumber))
             .catch { [weak self] in .error(self?.filterNetworkConnection($0) ?? $0) }
             .map { [weak self] response in
                 
@@ -70,7 +70,7 @@ public class DefaultAuthInputValidationRepository: AuthInputValidationRepository
     }
     
     public func requestCheckingIdDuplication(id: String) -> RxSwift.Single<Entity.BoolResult> {
-        networkService.request(api: .checkIdDuplication(id: id))
+        networkService.requestWithoutToken(api: .checkIdDuplication(id: id))
             .catch { [weak self] in .error(self?.filterNetworkConnection($0) ?? $0) }
             .map { [weak self] response in
                 

--- a/project/Projects/Data/ConcreteRepository/Auth/DefaultAuthRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Auth/DefaultAuthRepository.swift
@@ -39,7 +39,7 @@ public class DefaultAuthRepository: AuthRepository {
                 case 201:
                     return .success(true)
                 default:
-                    return .failure(self.decodeError(of: CenterRegisterError.self, data: response.data))
+                    return .failure(self.decodeError(of: AuthError.self, data: response.data))
                 }
             }
     }
@@ -75,7 +75,7 @@ public class DefaultAuthRepository: AuthRepository {
                         }
                     }
                 }
-                return .failure(self.decodeError(of: CenterRegisterError.self, data: response.data))
+                return .failure(self.decodeError(of: AuthError.self, data: response.data))
             }
     }
 }

--- a/project/Projects/Data/ConcreteRepository/RepositoryBase+Extension.swift
+++ b/project/Projects/Data/ConcreteRepository/RepositoryBase+Extension.swift
@@ -9,6 +9,7 @@ import Foundation
 import Entity
 import RepositoryInterface
 import Moya
+import NetworkDataSource
 
 extension RepositoryBase {
     
@@ -33,6 +34,14 @@ extension RepositoryBase {
     }
     
     func filterNetworkConnection(_ error: Error) -> URLError? {
+        
+        // 데이터소스 에러
+        if let dataSourceError = error as? DataSourceError {
+            #if DEBUG
+            print("데이터 소스 에러: \(error.localizedDescription)")
+            #endif
+            return nil
+        }
         
         guard let moyaError = error as? MoyaError, case .underlying(let err, _) = moyaError, let afError = err.asAFError, afError.isSessionTaskError else {
             return nil

--- a/project/Projects/Data/ConcretesTests/ConcretesTests.swift
+++ b/project/Projects/Data/ConcretesTests/ConcretesTests.swift
@@ -14,17 +14,39 @@ final class ConcretesTests: XCTestCase {
     
     func testToken() {
             
-        // TODO: 토큰 API구현이후 테스트 코드 작성 예정
+        // TODO: 로컬 맵핑 테스트
         
 //        let expectation = expectation(description: "Test function")
 //        
-//        let testStore = TestKeyValueStore()
+//        let repo = AuthService(
+//            keyValueStore: TestKeyValueStore()
+//        )
 //        
-//        let testService = DefaultTestService(keyValueStore: testStore)
+//        let disposeBag = DisposeBag()
 //        
-//        let single = testService.testRequest()
+//        let data = CenterRegistrationDTO(
+//            identifier: "test1234",
+//            password: "testpassword1234",
+//            phoneNumber: "010-4444-5555",
+//            managerName: "최준영",
+//            centerBusinessRegistrationNumber: "000-00-00000"
+//        )
 //
-//        waitForExpectations(timeout: 10, handler: nil)
+//        
+//        repo
+//            .request(api: .centerLogin(
+//                id: "test1234",
+//                password: "testpassword1234")
+//            )
+//            .subscribe { response in
+//            
+//            print(response)
+//            
+//            expectation.fulfill()
+//        }
+//        .disposed(by: disposeBag)
+//        
+//        waitForExpectations(timeout: 60, handler: nil)
     }
     
     func testAuth() {

--- a/project/Projects/Data/NetworkDataSource/API/Auth/AuthAPI.swift
+++ b/project/Projects/Data/NetworkDataSource/API/Auth/AuthAPI.swift
@@ -20,6 +20,7 @@ public enum AuthAPI {
     case checkIdDuplication(id: String)
     case registerCenterAccount(data: Data)
     case centerLogin(id: String, password: String)
+    case reissueToken(refreshToken: String)
 }
 
 extension AuthAPI: BaseAPI {
@@ -41,6 +42,8 @@ extension AuthAPI: BaseAPI {
             return .post
         case .centerLogin:
             return .post
+        case .reissueToken:
+            return .post
         }
     }
     
@@ -58,6 +61,8 @@ extension AuthAPI: BaseAPI {
             "center/join"
         case .centerLogin:
             "center/login"
+        case .reissueToken:
+            "center/refresh"
         }
     }
     
@@ -72,6 +77,8 @@ extension AuthAPI: BaseAPI {
         case .centerLogin(let id, let password):
             params["identifier"] = id
             params["password"] = password
+        case .reissueToken(let refreshToken):
+            params["refreshToken"] = refreshToken
         default:
             break
         }
@@ -94,6 +101,8 @@ extension AuthAPI: BaseAPI {
         case .registerCenterAccount(let data):
             return .requestData(data)
         case .centerLogin:
+            return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
+        case .reissueToken:
             return .requestParameters(parameters: bodyParameters ?? [:], encoding: parameterEncoding)
         default:
             return .requestPlain

--- a/project/Projects/Data/NetworkDataSource/API/BaseAPI.swift
+++ b/project/Projects/Data/NetworkDataSource/API/BaseAPI.swift
@@ -42,4 +42,15 @@ public extension BaseAPI {
         
         return ["Content-Type": "application/json"]
     }
+    
+    var validationType: ValidationType {
+        .customCodes(
+            [
+                200,
+                201,
+                204,
+                400,
+            ]
+        )
+    }
 }

--- a/project/Projects/Data/NetworkDataSource/Service/Auth/CenterRegisterService.swift
+++ b/project/Projects/Data/NetworkDataSource/Service/Auth/CenterRegisterService.swift
@@ -1,5 +1,5 @@
 //
-//  CenterRegisterService.swift
+//  AuthService.swift
 //  NetworkDataSource
 //
 //  Created by choijunios on 7/8/24.
@@ -7,6 +7,6 @@
 
 import Foundation
 
-public class CenterRegisterService: BaseNetworkService<AuthAPI> {
+public class AuthService: BaseNetworkService<AuthAPI> {
     public init() { }
 }

--- a/project/Projects/Data/NetworkDataSource/Service/Auth/CenterRegisterService.swift
+++ b/project/Projects/Data/NetworkDataSource/Service/Auth/CenterRegisterService.swift
@@ -8,5 +8,10 @@
 import Foundation
 
 public class AuthService: BaseNetworkService<AuthAPI> {
+    
     public init() { }
+    
+    public override init(keyValueStore: KeyValueStore) {
+        super.init(keyValueStore: keyValueStore)
+    }
 }

--- a/project/Projects/Data/NetworkDataSource/Service/BaseNetworkService.swift
+++ b/project/Projects/Data/NetworkDataSource/Service/BaseNetworkService.swift
@@ -75,17 +75,72 @@ public class BaseNetworkService<TagetAPI: BaseAPI> {
         completion(.success(adaptedRequest))
     }
     
+    private let tokenSession: Session = {
+       
+        let configuration = URLSessionConfiguration.default
+        
+        // 단일 요청이 완료되는데 걸리는 최대 시간, 초과시 타임아웃
+        configuration.timeoutIntervalForRequest = 10
+        
+        // 하나의 리소스를 로드하는데 걸리는 시간, 재시도를 포함한다 초과시 타임아웃
+        configuration.timeoutIntervalForResource = 10
+        
+        // Cache policy: 로컬캐시를 무시하고 항상 새로운 데이터를 가져온다.
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        
+        let session = Session(configuration: configuration)
+        
+        return session
+    }()
+    
     lazy var tokenRetrier = Retrier { [weak self] request, session, error, completion in
         
         if let httpResponse = request.response {
             
             if httpResponse.statusCode == 401 {
                 
-                // TODO: 토큰 재발급후 요청 재시도
+                guard let self, let (_, refreshToken) = self.keyValueStore.getAuthToken() else {
+                    return completion(.doNotRetryWithError(DataSourceError.localStorageFetchFailure))
+                }
+                
+                let provider = MoyaProvider<AuthAPI>(session: self.tokenSession)
+                
+                provider.rx
+                    .request(.reissueToken(refreshToken: refreshToken))
+                    .subscribe(onSuccess: { [weak self] response in
+                        if response.statusCode == 200 {
+                            // 정상 응답
+                            if let dict = try? JSONSerialization.jsonObject(with: response.data) as? [String: String],
+                               let accessToken = dict["accessToken"],
+                               let refreshToken = dict["refreshToken"] {
+                                do {
+                                    try self?.keyValueStore.saveAuthToken(
+                                        accessToken: accessToken,
+                                        refreshToken: refreshToken
+                                    )
+                                    completion(.retry)
+                                } catch {
+                                    // 로컬저장소 저장 에러
+                                    completion(.doNotRetryWithError(DataSourceError.localStorageSaveFailure))
+                                }
+                            } else {
+                                // 디코딩 에러
+                                completion(.doNotRetryWithError(DataSourceError.decodingError))
+                            }
+                        } else {
+                            // 서버에러, 클라이언트 에러
+                            completion(.doNotRetryWithError(error))
+                        }
+                    }, onFailure: { error in
+                        // Validation을 통과하지 못한 에러
+                        completion(.doNotRetryWithError(error))
+                    })
+                    .disposed(by: self.disposeBag)
+                    
+            } else {
+                completion(.doNotRetry)
             }
         }
-            
-        completion(.doNotRetry)
     }
     
     /// Token을 요구하지 않는 요청이 사용한다.
@@ -105,6 +160,7 @@ public class BaseNetworkService<TagetAPI: BaseAPI> {
         return Session(configuration: configuration)
     }()
     
+    let disposeBag = DisposeBag()
 }
 
 // MARK: DataRequest

--- a/project/Projects/Data/NetworkDataSource/Service/BaseNetworkService.swift
+++ b/project/Projects/Data/NetworkDataSource/Service/BaseNetworkService.swift
@@ -28,6 +28,13 @@ public class BaseNetworkService<TagetAPI: BaseAPI> {
         return provider
     }()
     
+    private lazy var withoutTokenProvider: MoyaProvider<TagetAPI> = {
+        
+        let provider = MoyaProvider<TagetAPI>(session: sessionWithoutToken)
+        
+        return provider
+    }()
+    
     lazy var sessionWithToken: Session = {
         
         let configuration = URLSessionConfiguration.default
@@ -81,6 +88,23 @@ public class BaseNetworkService<TagetAPI: BaseAPI> {
         completion(.doNotRetry)
     }
     
+    /// Token을 요구하지 않는 요청이 사용한다.
+    let sessionWithoutToken: Session = {
+       
+        let configuration = URLSessionConfiguration.default
+        
+        // 단일 요청이 완료되는데 걸리는 최대 시간, 초과시 타임아웃
+        configuration.timeoutIntervalForRequest = 10
+        
+        // 하나의 리소스를 로드하는데 걸리는 시간, 재시도를 포함한다 초과시 타임아웃
+        configuration.timeoutIntervalForResource = 10
+        
+        // Cache policy: 로컬캐시를 무시하고 항상 새로운 데이터를 가져온다.
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        
+        return Session(configuration: configuration)
+    }()
+    
 }
 
 // MARK: DataRequest
@@ -132,5 +156,11 @@ public extension BaseNetworkService {
                     }
                 })
         }
+    }
+    
+    /// 토큰을 사용하지 않는 요청입니다.
+    func requestWithoutToken(api: TagetAPI) -> Single<Response> {
+        
+        self.withoutTokenProvider.rx.request(api)
     }
 }

--- a/project/Projects/Data/NetworkDataSource/Service/BaseNetworkService.swift
+++ b/project/Projects/Data/NetworkDataSource/Service/BaseNetworkService.swift
@@ -13,7 +13,7 @@ import RxMoya
 
 public class BaseNetworkService<TagetAPI: BaseAPI> {
     
-    private let keyValueStore: KeyValueStore
+    public let keyValueStore: KeyValueStore
     
     init(keyValueStore: KeyValueStore = KeyChainList.shared) {
         self.keyValueStore = keyValueStore

--- a/project/Projects/Data/NetworkDataSource/Util/Error/DataSourceError.swift
+++ b/project/Projects/Data/NetworkDataSource/Util/Error/DataSourceError.swift
@@ -1,0 +1,15 @@
+//
+//  DataSourceError.swift
+//  NetworkDataSource
+//
+//  Created by choijunios on 7/10/24.
+//
+
+import Foundation
+
+public enum DataSourceError: Error {
+    
+    case decodingError
+    case localStorageSaveFailure
+    case localStorageFetchFailure
+}

--- a/project/Projects/Data/NetworkDataSource/Util/KeyValueStore/KeyChainList.swift
+++ b/project/Projects/Data/NetworkDataSource/Util/KeyValueStore/KeyChainList.swift
@@ -20,18 +20,44 @@ class KeyChainList {
 extension KeyChainList: KeyValueStore {
     
     func save(key: String, value: String) throws {
-        try keyChain.set(value, key: key)
+        do {
+            try keyChain.set(value, key: key)
+            #if DEBUG
+            print("KeyChain Save Success: \(key)")
+            #endif
+        } catch {
+            #if DEBUG
+            print("UserDefaults Save Success: \(key)")
+            #endif
+            UserDefaults.standard.setValue(value, forKey: key)
+        }
     }
     
     func delete(key: String) throws {
         try keyChain.remove(key)
+        UserDefaults.standard.removeObject(forKey: key)
     }
     
     func removeAll() throws {
         try keyChain.removeAll()
+        
+        // UserDefaults의 경우 수동으로 정보를 삭제합니다.
+        UserDefaults.standard.removeObject(forKey: Key.Auth.kaccessToken)
+        UserDefaults.standard.removeObject(forKey: Key.Auth.krefreshToken)
     }
     
     func get(key: String) -> String? {
-        try? keyChain.get(key)
+        if let value = try? keyChain.get(key) {
+            #if DEBUG
+            print("get value from KeyChain: \(key)")
+            #endif
+            return value
+        } else if let value = UserDefaults.standard.string(forKey: key) {
+            #if DEBUG
+            print("get value from UserDefaults: \(key)")
+            #endif
+            return value
+        }
+        return nil
     }
 }

--- a/project/Projects/Domain/Entity/Error/Auth/AuthError.swift
+++ b/project/Projects/Domain/Entity/Error/Auth/AuthError.swift
@@ -1,0 +1,22 @@
+//
+//  AuthError.swift
+//  Entity
+//
+//  Created by choijunios on 7/10/24.
+//
+
+import Foundation
+
+public enum AuthError: String, CustomError {
+    
+    // undefinedError
+    case undefinedError="Err-000"
+    
+    public var message: String {
+        switch self {
+        // MARK: undefinedError
+        case .undefinedError:
+            "❌ 정의되지 않은 에러타입입니다. ❌"
+        }
+    }
+}

--- a/project/Projects/Domain/Entity/Error/Auth/InputValidationError.swift
+++ b/project/Projects/Domain/Entity/Error/Auth/InputValidationError.swift
@@ -1,13 +1,13 @@
 //
-//  CenterRegisterError.swift
+//  InputValidationError.swift
 //  Entity
 //
-//  Created by choijunios on 7/8/24.
+//  Created by choijunios on 7/10/24.
 //
 
 import Foundation
 
-public enum CenterRegisterError: String, CustomError {
+public enum InputValidationError: String, CustomError {
     
     case InvalidSmsVerificationNumber="SMS-001"
     case SmsVerificationNumberNotFound="SMS-002"

--- a/project/Projects/Domain/Entity/Error/IdleError.swift
+++ b/project/Projects/Domain/Entity/Error/IdleError.swift
@@ -51,6 +51,14 @@ public class IdleError: Error {
         )
     }
     
+    public static var localSaveError: IdleError {
+        IdleError(
+            code: "Local-004",
+            message: "토큰을 로컬환경에 저장하는데 실패했습니다.",
+            timestamp: ISO8601DateFormatter().string(from: Date())
+        )
+    }
+    
     // MARK: static ServerError
     public static var systemError: IdleError {
         IdleError(

--- a/project/Projects/Presentation/Feature/Auth/Sources/View/Center/Login/CenterLoginViewController.swift
+++ b/project/Projects/Presentation/Feature/Auth/Sources/View/Center/Login/CenterLoginViewController.swift
@@ -246,6 +246,8 @@ public class CenterLoginViewController: DisposableViewController {
             .onCustomState { textField in
                 textField.layer.borderColor = textField.normalBorderColor.cgColor
             }
+        
+        coordinator?.parent?.authFinished()
     }
     
     


### PR DESCRIPTION
## 변경사항
- 특정 요청에 토큰헤더 추가
- 토큰 만료시 만료된 토큰을 자동으로 refresh하고 요청 재시도
- 에러처리 로직

### JWT토큰
로그인 성공시 JWT토큰이 내부 키체인에 저장됩니다.
토큰 저장로직은 Data레이어의 레포지토리에 존재합니다.
모든 네트워크 서비스가 하나의 KeyStore를 공유하도록 개발할 예정입니다.
아직 KeyChain사용에 대한 Entitlement는 포함하지 않은 상황이라 실제 디바이스에서는 해당 기능에서 에러가 발생합니다.
![스크린샷 2024-07-10 오후 4 08 34](https://github.com/3IDLES/idle-iOS/assets/106458638/a0f7d8a6-88f4-4efd-b003-7bea92d9b1bf)

### 에러처리 로직

![image](https://github.com/3IDLES/idle-iOS/assets/106458638/19cd82ac-54d0-47a2-bd36-a9088debe715)
