### PR TITLE
[IDLE-275] 요양보호사 프로필 최신 UI반영 및 API연동

### DIFF
--- a/project/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency.swift
+++ b/project/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency.swift
@@ -43,6 +43,7 @@ public extension ModuleDependency {
         public static let RxMoya: TargetDependency = .external(name: "RxMoya")
         public static let FSCalendar: TargetDependency = .external(name: "FSCalendar")
         public static let NaverMapSDKForSPM: TargetDependency = .external(name: "Junios.NMapSDKForSPM")
+        public static let KingFisher: TargetDependency = .external(name: "Kingfisher")
     }
 }
 

--- a/project/Projects/Data/ConcreteRepository/UserInfo/DefaultUserProfileRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/UserInfo/DefaultUserProfileRepository.swift
@@ -94,7 +94,34 @@ public class DefaultUserProfileRepository: UserProfileRepository {
     
     /// 요양보호사 프로필 정보를 업데이트 합니다.
     public func updateWorkerProfile(stateObject: WorkerProfileStateObject) -> RxSwift.Single<Void> {
-        let encoded = try! JSONEncoder().encode(stateObject)
+        
+        var availableValues: [String: Any] = [:]
+        
+        if let experienceYear = stateObject.experienceYear {
+            availableValues["experienceYear"] = experienceYear
+        }
+
+        if let roadNameAddress = stateObject.roadNameAddress {
+            availableValues["roadNameAddress"] = roadNameAddress
+        }
+
+        if let lotNumberAddress = stateObject.lotNumberAddress {
+            availableValues["lotNumberAddress"] = lotNumberAddress
+        }
+
+        if let introduce = stateObject.introduce {
+            availableValues["introduce"] = introduce
+        }
+
+        if let speciality = stateObject.speciality {
+            availableValues["speciality"] = speciality
+        }
+
+        if let isJobFinding = stateObject.isJobFinding {
+            availableValues["jobSearchStatus"] = isJobFinding ? "YES" : "NO"
+        }
+        
+        let encoded = try! JSONSerialization.data(withJSONObject: availableValues)
         
         return userInformationService
             .request(api: .updateWorkerProfile(data: encoded), with: .withToken)

--- a/project/Projects/Data/ConcreteRepository/UserInfo/DefaultUserProfileRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/UserInfo/DefaultUserProfileRepository.swift
@@ -12,7 +12,7 @@ import RepositoryInterface
 import NetworkDataSource
 
 public class DefaultUserProfileRepository: UserProfileRepository {
-    
+
     let userInformationService: UserInformationService
     let externalRequestService: ExternalRequestService
     
@@ -51,9 +51,9 @@ public class DefaultUserProfileRepository: UserProfileRepository {
         
         switch mode {
         case .myProfile:
-            api = .getCenterProfile
+            api = .getMyCenterProfile
         case .otherProfile(let id):
-            api = .getOtherCenterProfile(id: id)
+            api = .getCenterProfile(id: id)
         }
         
         return userInformationService
@@ -63,7 +63,7 @@ public class DefaultUserProfileRepository: UserProfileRepository {
     
     public func getCenterProfile(id: String) -> Single<CenterProfileVO> {
         userInformationService
-            .requestDecodable(api: .getOtherCenterProfile(id: id), with: .withToken)
+            .requestDecodable(api: .getCenterProfile(id: id), with: .withToken)
             .map { (dto: CenterProfileDTO) in dto.toEntity() }
     }
     
@@ -73,6 +73,31 @@ public class DefaultUserProfileRepository: UserProfileRepository {
                 officeNumber: phoneNumber,
                 introduce: introduction
             ), with: .withToken)
+            .map { _ in return () }
+    }
+    
+    /// 요양보호사 프로필 정보를 가져옵니다.
+    public func getWorkerProfile(mode: Entity.ProfileMode) -> RxSwift.Single<Entity.WorkerProfileVO> {
+        var api: UserInformationAPI!
+        
+        switch mode {
+        case .myProfile:
+            api = .getMyWorkerProfile
+        case .otherProfile(let id):
+            api = .getOtherWorkerProfile(id: id)
+        }
+        
+        return userInformationService
+            .requestDecodable(api: api, with: .withToken)
+            .map { (dto: CarerProfileDTO) in dto.toVO() }
+    }
+    
+    /// 요양보호사 프로필 정보를 업데이트 합니다.
+    public func updateWorkerProfile(stateObject: WorkerProfileStateObject) -> RxSwift.Single<Void> {
+        let encoded = try! JSONEncoder().encode(stateObject)
+        
+        return userInformationService
+            .request(api: .updateWorkerProfile(data: encoded), with: .withToken)
             .map { _ in return () }
     }
     

--- a/project/Projects/Data/NetworkDataSource/API/UserInformationAPI.swift
+++ b/project/Projects/Data/NetworkDataSource/API/UserInformationAPI.swift
@@ -27,9 +27,15 @@ public enum UserInformationAPI {
     case registerCenterProfile(data: Data)
     
     // 프로필 조회
-    case getCenterProfile
-    case getOtherCenterProfile(id: String)
+    // - Center
+    case getMyCenterProfile
+    case getCenterProfile(id: String)
     case updateCenterProfile(officeNumber: String, introduce: String?)
+    
+    // - Worker
+    case getMyWorkerProfile
+    case getOtherWorkerProfile(id: String)
+    case updateWorkerProfile(data: Data)
     
     // 프로필 사진 업로드
     case getPreSignedUrl(userType: UserType, imageExt: String)
@@ -49,10 +55,16 @@ extension UserInformationAPI: BaseAPI {
         switch self {
         case .registerCenterProfile:
             "center/my/profile"
-        case .getCenterProfile:
+        case .getMyCenterProfile:
             "center/my/profile"
-        case .getOtherCenterProfile(let id):
+        case .getCenterProfile(let id):
             "center/profile/\(id)"
+        case .getMyWorkerProfile:
+            "carer/my/profile"
+        case .getOtherWorkerProfile(let id):
+            "carer/profile/\(id)"
+        case .updateWorkerProfile:
+            "carer/my/profile"
         case .updateCenterProfile:
             "center/my/profile"
         case .getPreSignedUrl(let type, _):
@@ -66,9 +78,9 @@ extension UserInformationAPI: BaseAPI {
         switch self {
         case .registerCenterProfile:
             .post
-        case .getCenterProfile:
+        case .getMyCenterProfile:
             .get
-        case .getOtherCenterProfile:
+        case .getCenterProfile:
             .get
         case .updateCenterProfile:
             .patch
@@ -76,6 +88,12 @@ extension UserInformationAPI: BaseAPI {
             .get
         case .imageUploadSuccessCallback:
             .post
+        case .getMyWorkerProfile:
+            .get
+        case .getOtherWorkerProfile(id: let id):
+            .get
+        case .updateWorkerProfile(data: let data):
+            .patch
         }
     }
     
@@ -107,6 +125,8 @@ extension UserInformationAPI: BaseAPI {
                 "imageFileExtension": imageExt
             ]
             return .requestParameters(parameters: params, encoding: parameterEncoding)
+        case .updateWorkerProfile(let data):
+            return .requestData(data)
         default:
             return .requestPlain
         }

--- a/project/Projects/Data/NetworkDataSource/DTO/UserInfo/WorkerProfileDTO.swift
+++ b/project/Projects/Data/NetworkDataSource/DTO/UserInfo/WorkerProfileDTO.swift
@@ -1,0 +1,42 @@
+//
+//  WorkerProfileDTO.swift
+//  NetworkDataSource
+//
+//  Created by choijunios on 8/10/24.
+//
+
+import Foundation
+import Entity
+
+public struct CarerProfileDTO: Codable {
+    let carerName: String
+    let age: Int
+    let gender: String
+    let experienceYear: Int?
+    let phoneNumber: String
+    let roadNameAddress: String
+    let lotNumberAddress: String
+    let introduce: String?
+    let speciality: String?
+    let profileImageUrl: String?
+    let jobSearchStatus: String
+    
+    
+    public func toVO() -> WorkerProfileVO {
+        
+        return .init(
+            profileImageURL: profileImageUrl,
+            nameText: carerName,
+            isLookingForJob: jobSearchStatus == "YES",
+            age: age,
+            gender: gender == "MAN" ? .male : .female,
+            expYear: experienceYear,
+            address: .init(
+                roadAddress: roadNameAddress,
+                jibunAddress: lotNumberAddress
+            ),
+            introductionText: introduce ?? "",
+            specialty: speciality ?? ""
+        )
+    }
+}

--- a/project/Projects/Data/NetworkDataSource/DTO/UserInfo/WorkerProfileDTO.swift
+++ b/project/Projects/Data/NetworkDataSource/DTO/UserInfo/WorkerProfileDTO.swift
@@ -27,6 +27,7 @@ public struct CarerProfileDTO: Codable {
         return .init(
             profileImageURL: profileImageUrl,
             nameText: carerName,
+            phoneNumber: phoneNumber,
             isLookingForJob: jobSearchStatus == "YES",
             age: age,
             gender: gender == "MAN" ? .male : .female,

--- a/project/Projects/Domain/ConcreteUseCase/UserInfo/DefaultWorkerProfileUseCase.swift
+++ b/project/Projects/Domain/ConcreteUseCase/UserInfo/DefaultWorkerProfileUseCase.swift
@@ -1,0 +1,86 @@
+//
+//  DefaultWorkerProfileUseCase.swift
+//  ConcreteUseCase
+//
+//  Created by choijunios on 8/10/24.
+//
+
+import Foundation
+import RxSwift
+import Entity
+import UseCaseInterface
+import RepositoryInterface
+
+public class DefaultWorkerProfileUseCase: WorkerProfileUseCase {
+    
+    let repository: UserProfileRepository
+    
+    public init(repository: UserProfileRepository) {
+        self.repository = repository
+    }
+    
+    public func getProfile(mode: ProfileMode) -> Single<Result<WorkerProfileVO, UserInfoError>> {
+        convert(task: repository.getWorkerProfile(mode: mode)) { [unowned self] error in
+            toDomainError(error: error)
+        }
+    }
+    
+    public func updateProfile(stateObject: WorkerProfileStateObject, imageInfo: ImageUploadInfo?) -> Single<Result<Void, UserInfoError>> {
+
+        var updateText: Single<Void>!
+        var updateImage: Single<Void>!
+        
+        updateText = repository.updateWorkerProfile(
+            stateObject: stateObject
+        )
+        
+        if let imageInfo {
+            updateImage = repository.uploadImage(
+                .center,
+                imageInfo: imageInfo
+            )
+        } else {
+            updateImage = .just(())
+        }
+        
+        let updateTextResult = updateText
+            .catch { error in
+                if let httpExp = error as? HTTPResponseException {
+                    let newError = HTTPResponseException(
+                        status: httpExp.status,
+                        rawCode: "Err-001",
+                        timeStamp: httpExp.timeStamp
+                    )
+                    
+                    return .error(newError)
+                }
+                return .error(error)
+            }
+          
+        let uploadImageResult = updateImage
+            .catch { error in
+                if let httpExp = error as? HTTPResponseException {
+                    let newError = HTTPResponseException(
+                        status: httpExp.status,
+                        rawCode: "Err-002",
+                        timeStamp: httpExp.timeStamp
+                    )
+                    
+                    return .error(newError)
+                }
+                return .error(error)
+            }
+        
+        let task = Observable
+            .zip(
+                updateTextResult.asObservable(),
+                uploadImageResult.asObservable()
+            )
+            .map { _ in () }
+            .asSingle()
+        
+        return convert(task: task) { [unowned self] error in
+            toDomainError(error: error)
+        }
+    }
+}

--- a/project/Projects/Domain/Entity/State/Profile/WorkerProfileStateObject.swift
+++ b/project/Projects/Domain/Entity/State/Profile/WorkerProfileStateObject.swift
@@ -1,0 +1,28 @@
+//
+//  WorkerProfileStateObject.swift
+//  Entity
+//
+//  Created by choijunios on 8/10/24.
+//
+
+import Foundation
+
+public struct WorkerProfileStateObject: Codable {
+    public var experienceYear: Int?
+    public var roadNameAddress: String?
+    public var lotNumberAddress: String?
+    public var introduce: String?
+    public var speciality: String?
+    public var isJobFinding: Bool?
+    
+    public init(experienceYear: Int? = nil, roadNameAddress: String? = nil, lotNumberAddress: String? = nil, introduce: String? = nil, speciality: String? = nil, isJobFinding: Bool? = nil) {
+        self.experienceYear = experienceYear
+        self.roadNameAddress = roadNameAddress
+        self.lotNumberAddress = lotNumberAddress
+        self.introduce = introduce
+        self.speciality = speciality
+        self.isJobFinding = isJobFinding
+    }
+    
+    public static let `default`: WorkerProfileStateObject = .init()
+}

--- a/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
+++ b/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
@@ -36,17 +36,17 @@ public struct WorkerProfileVO {
 
 public extension WorkerProfileVO {
     static let mock: WorkerProfileVO = .init(
-        profileImageURL: "https://dummyimage.com/500x500/000/fff&text=worker+profile",
-        nameText: "홍갈동",
+        profileImageURL: nil,
+        nameText: "",
         isLookingForJob: true,
         age: 58,
         gender: .female,
         expYear: nil,
         address: .init(
-            roadAddress: "서울특별시 강남구 삼성동 512-3",
-            jibunAddress: "서울특별시 강남구 삼성동 63-43"
+            roadAddress: "",
+            jibunAddress: ""
         ),
-        introductionText: "안녕하세요 반갑습니다!",
-        specialty: "말동무 잘함"
+        introductionText: "",
+        specialty: ""
     )
 }

--- a/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
+++ b/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
@@ -9,41 +9,41 @@ import Foundation
 
 public struct WorkerProfileVO {
     
-    public let profileImageURL: URL?
+    public let profileImageURL: String?
     
     
     public let nameText: String
     public let isLookingForJob: Bool
-    public let ageText: String
-    public let genderText: String
-    public let expYearText: String
+    public let age: Int
+    public let gender: Gender
+    public let expYear: Int?
     public let addressText: String
     public let introductionText: String
-    public let abilitiesText: String
+    public let specialty: String
     
-    public init(profileImageURL: URL?, nameText: String, isLookingForJob: Bool, ageText: String, genderText: String, expYearText: String, addressText: String, introductionText: String, abilitiesText: String) {
+    public init(profileImageURL: String?, nameText: String, isLookingForJob: Bool, age: Int, gender: Gender, expYear: Int?, addressText: String, introductionText: String, specialty: String) {
         self.profileImageURL = profileImageURL
         self.nameText = nameText
         self.isLookingForJob = isLookingForJob
-        self.ageText = ageText
-        self.genderText = genderText
-        self.expYearText = expYearText
+        self.age = age
+        self.gender = gender
+        self.expYear = expYear
         self.addressText = addressText
         self.introductionText = introductionText
-        self.abilitiesText = abilitiesText
+        self.specialty = specialty
     }
 }
 
 public extension WorkerProfileVO {
-    static let mock = WorkerProfileVO(
-        profileImageURL: URL(string: "https://dummyimage.com/500x500/000/fff&text=worker+profile"),
+    static let mock: WorkerProfileVO = .init(
+        profileImageURL: "https://dummyimage.com/500x500/000/fff&text=worker+profile",
         nameText: "홍갈동",
         isLookingForJob: true,
-        ageText: "58세",
-        genderText: Gender.female.twoLetterKoreanWord,
-        expYearText: "1년차",
+        age: 58,
+        gender: .female,
+        expYear: nil,
         addressText: "서울특별시 강남구 삼성동 512-3",
         introductionText: "안녕하세요 반갑습니다!",
-        abilitiesText: "말동무 잘함"
+        specialty: "말동무 잘함"
     )
 }

--- a/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
+++ b/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
@@ -17,18 +17,18 @@ public struct WorkerProfileVO {
     public let age: Int
     public let gender: Gender
     public let expYear: Int?
-    public let addressText: String
+    public let address: AddressInformation
     public let introductionText: String
     public let specialty: String
     
-    public init(profileImageURL: String?, nameText: String, isLookingForJob: Bool, age: Int, gender: Gender, expYear: Int?, addressText: String, introductionText: String, specialty: String) {
+    public init(profileImageURL: String?, nameText: String, isLookingForJob: Bool, age: Int, gender: Gender, expYear: Int?, address: AddressInformation, introductionText: String, specialty: String) {
         self.profileImageURL = profileImageURL
         self.nameText = nameText
         self.isLookingForJob = isLookingForJob
         self.age = age
         self.gender = gender
         self.expYear = expYear
-        self.addressText = addressText
+        self.address = address
         self.introductionText = introductionText
         self.specialty = specialty
     }
@@ -42,7 +42,10 @@ public extension WorkerProfileVO {
         age: 58,
         gender: .female,
         expYear: nil,
-        addressText: "서울특별시 강남구 삼성동 512-3",
+        address: .init(
+            roadAddress: "서울특별시 강남구 삼성동 512-3",
+            jibunAddress: "서울특별시 강남구 삼성동 63-43"
+        ),
         introductionText: "안녕하세요 반갑습니다!",
         specialty: "말동무 잘함"
     )

--- a/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
+++ b/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
@@ -13,6 +13,7 @@ public struct WorkerProfileVO {
     
     
     public let nameText: String
+    public let phoneNumber: String
     public let isLookingForJob: Bool
     public let age: Int
     public let gender: Gender
@@ -21,9 +22,21 @@ public struct WorkerProfileVO {
     public let introductionText: String
     public let specialty: String
     
-    public init(profileImageURL: String?, nameText: String, isLookingForJob: Bool, age: Int, gender: Gender, expYear: Int?, address: AddressInformation, introductionText: String, specialty: String) {
+    public init(
+        profileImageURL: String?,
+        nameText: String,
+        phoneNumber: String,
+        isLookingForJob: Bool,
+        age: Int,
+        gender: Gender,
+        expYear: Int?,
+        address: AddressInformation,
+        introductionText: String,
+        specialty: String
+    ) {
         self.profileImageURL = profileImageURL
         self.nameText = nameText
+        self.phoneNumber = phoneNumber
         self.isLookingForJob = isLookingForJob
         self.age = age
         self.gender = gender
@@ -38,6 +51,7 @@ public extension WorkerProfileVO {
     static let mock: WorkerProfileVO = .init(
         profileImageURL: nil,
         nameText: "",
+        phoneNumber: "",
         isLookingForJob: true,
         age: 58,
         gender: .female,

--- a/project/Projects/Domain/RepositoryInterface/UserInfo/UserProfileRepository.swift
+++ b/project/Projects/Domain/RepositoryInterface/UserInfo/UserProfileRepository.swift
@@ -18,4 +18,7 @@ public protocol UserProfileRepository: RepositoryBase {
     
     // ImageUpload
     func uploadImage(_ userType: UserType, imageInfo: ImageUploadInfo) -> Single<Void>
+    
+    func getWorkerProfile(mode: ProfileMode) -> Single<WorkerProfileVO>
+    func updateWorkerProfile(stateObject: WorkerProfileStateObject) -> Single<Void>
 }

--- a/project/Projects/Domain/UseCaseInterface/UserInfo/CenterProfileUseCase.swift
+++ b/project/Projects/Domain/UseCaseInterface/UserInfo/CenterProfileUseCase.swift
@@ -19,6 +19,7 @@ import Entity
 public protocol CenterProfileUseCase: UseCaseBase {
     
     /// 1. 나의 센터/다른 센터 프로필 정보 조회
+    /// 6. 특정 센터의 프로필 불러오기
     func getProfile(mode: ProfileMode) -> Single<Result<CenterProfileVO, UserInfoError>>
     
     /// 2. 센터 프로필 정보 업데이트(전화번호, 센터소개글)

--- a/project/Projects/Domain/UseCaseInterface/UserInfo/WorkerProfileUseCase.swift
+++ b/project/Projects/Domain/UseCaseInterface/UserInfo/WorkerProfileUseCase.swift
@@ -1,0 +1,30 @@
+//
+//  WorkerProfileUseCase.swift
+//  UseCaseInterface
+//
+//  Created by choijunios on 8/10/24.
+//
+
+import Foundation
+import RxSwift
+import Entity
+
+/// 1. 나의(요보) 프로필 정보 조회
+/// 2. 나의(요보) 프로필 정보 업데이트(텍스트 데이터)
+/// 3. 나의(요보) 프로필 정보 업데이트(이미지, pre-signed-url)
+/// 4. 나의(요보) 프로필 정보 업데이트(이미지, pre-signed-url-callback)
+/// 5. 특정 요양보호사의 프로필 불러오기
+
+public protocol WorkerProfileUseCase: UseCaseBase {
+    
+    /// 1. 나의(요보) 프로필 정보 조회
+    /// 5. 특정 요양보호사의 프로필 불러오기
+    func getProfile(mode: ProfileMode) -> Single<Result<WorkerProfileVO, UserInfoError>>
+    
+    
+    /// 2. 나의(요보) 프로필 정보 업데이트(텍스트 데이터)
+    /// 3. 나의(요보) 프로필 정보 업데이트(이미지, pre-signed-url)
+    /// 4. 나의(요보) 프로필 정보 업데이트(이미지, pre-signed-url-callback)
+    func updateProfile(stateObject: WorkerProfileStateObject, imageInfo: ImageUploadInfo?) -> Single<Result<Void, UserInfoError>>
+
+}

--- a/project/Projects/Presentation/DSKit/Project.swift
+++ b/project/Projects/Presentation/DSKit/Project.swift
@@ -32,6 +32,7 @@ let proejct = Project(
                 D.ThirdParty.RxSwift,
                 D.ThirdParty.RxCocoa,
                 D.ThirdParty.FSCalendar,
+                D.ThirdParty.KingFisher,
             ],
             settings: .settings(
                 configurations: IdleConfiguration.presentationConfigurations

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Button/SlideStateButton.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Button/SlideStateButton.swift
@@ -46,9 +46,7 @@ public class SlideStateButton: UIView {
     
     // Observable
     /// 핫옵저버블 입니다.
-    public lazy var signal: Single<State> = stateObservable.asSingle()
-    
-    private let stateObservable: PublishRelay<State> = .init()
+    public let stateObservable: PublishRelay<State> = .init()
     private let disposeBag = DisposeBag()
     
     public override var intrinsicContentSize: CGSize {

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Button/SlideStateButton.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Button/SlideStateButton.swift
@@ -1,0 +1,174 @@
+//
+//  SlideStateButton.swift
+//  DSKit
+//
+//  Created by choijunios on 8/10/24.
+//
+
+import Foundation
+import UIKit
+import PresentationCore
+import RxCocoa
+import RxSwift
+import Entity
+
+public class SlideStateButton: UIView {
+    
+    public enum State {
+        case state1
+        case state2
+    }
+    
+    // Init
+    
+    // View
+    let state1Label: IdleLabel = {
+        let label = IdleLabel(typography: .Body3)
+        return label
+    }()
+    let state2Label: IdleLabel = {
+        let label = IdleLabel(typography: .Body3)
+        return label
+    }()
+    
+    let contentView: UIView = .init()
+    
+    let accentBackgroundView: UIView = {
+        let view = UIView()
+        return view
+    }()
+    
+    let idleTextColor = DSKitAsset.Colors.gray300.color
+    let accentTextColor = DSKitAsset.Colors.gray900.color
+    
+    lazy var state1Anchor: NSLayoutConstraint = accentBackgroundView.centerXAnchor.constraint(equalTo: state1Label.centerXAnchor)
+    lazy var state2Anchor: NSLayoutConstraint = accentBackgroundView.centerXAnchor.constraint(equalTo: state2Label.centerXAnchor)
+    
+    // Observable
+    /// 핫옵저버블 입니다.
+    public lazy var signal: Single<State> = stateObservable.asSingle()
+    
+    private let stateObservable: PublishRelay<State> = .init()
+    private let disposeBag = DisposeBag()
+    
+    public override var intrinsicContentSize: CGSize {
+        .init(width: 186, height: 36)
+    }
+    
+    public init(initialState: State = .state1) {
+        super.init(frame: .zero)
+        
+        setAppearance()
+        setLayout()
+        setObservable()
+        setGesture()
+        
+        setState(initialState)
+    }
+    
+    public required init?(coder: NSCoder) { fatalError() }
+    
+    private func setAppearance() {
+        self.backgroundColor = DSKitAsset.Colors.gray050.color
+        self.layer.cornerRadius = 18
+        self.clipsToBounds = true
+        
+        contentView.backgroundColor = DSKitAsset.Colors.gray050.color
+        contentView.layer.cornerRadius = 16
+        contentView.clipsToBounds = true
+        
+        accentBackgroundView.backgroundColor = .white
+        accentBackgroundView.layer.cornerRadius = 16
+    }
+    
+    private func setLayout() {
+        
+        [
+            accentBackgroundView,
+            state1Label,
+            state2Label
+        ].forEach {
+            contentView.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            state1Label.centerXAnchor.constraint(equalTo: contentView.centerXAnchor, constant: -45.5),
+            state1Label.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            
+            state2Label.centerXAnchor.constraint(equalTo: contentView.centerXAnchor, constant: 45.5),
+            state2Label.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            
+            accentBackgroundView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            accentBackgroundView.widthAnchor.constraint(equalToConstant: 100),
+            accentBackgroundView.heightAnchor.constraint(equalToConstant: 32),
+        ])
+        
+        
+        [
+            contentView
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview(contentView)
+        }
+        
+        NSLayoutConstraint.activate([
+            
+            contentView.topAnchor.constraint(equalTo: self.topAnchor, constant: 2),
+            contentView.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 2),
+            contentView.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -2),
+            contentView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -2),
+        ])
+    }
+    
+    private func setObservable() {
+        
+        
+    }
+    
+    private func setGesture() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped(_:)))
+        self.isUserInteractionEnabled = true
+        self.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc func labelTapped(_ sender: UITapGestureRecognizer) {
+        
+        guard let senderView = sender.view else { return }
+        
+        let touchLocation = sender.location(in: senderView)
+        
+        let currentState: State = touchLocation.x < senderView.bounds.width/2 ? .state1 : .state2
+        
+        stateObservable.accept(currentState)
+        
+        // State change
+        UIView.animate(withDuration: 0.35) { [weak self] in
+            
+            guard let self else { return }
+            
+            setState(currentState)
+            
+            layoutIfNeeded()
+        }
+    }
+    
+    public func setState(_ state: State) {
+        
+        state1Label.attrTextColor = state == .state1 ? accentTextColor : idleTextColor
+        state2Label.attrTextColor = state == .state2 ? accentTextColor : idleTextColor
+        
+        state1Anchor.isActive = state == .state1
+        state2Anchor.isActive = state == .state2
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview("Preview", traits: .defaultLayout) {
+    
+    let btn = SlideStateButton(initialState: .state1)
+    btn.state1Label.textString = "휴식중"
+    btn.state2Label.textString = "구직중"
+    
+    return btn
+}

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Button/SlideStateButton.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Button/SlideStateButton.swift
@@ -22,11 +22,11 @@ public class SlideStateButton: UIView {
     // Init
     
     // View
-    let state1Label: IdleLabel = {
+    public let state1Label: IdleLabel = {
         let label = IdleLabel(typography: .Body3)
         return label
     }()
-    let state2Label: IdleLabel = {
+    public let state2Label: IdleLabel = {
         let label = IdleLabel(typography: .Body3)
         return label
     }()

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Navigation/NavigationBarType1.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Navigation/NavigationBarType1.swift
@@ -15,7 +15,13 @@ public class NavigationBarType1: UIStackView {
     public let eventPublisher: PublishRelay<Void> = .init()
     
     // Init parameters
-    public let navigationTitle: String
+    public var navigationTitle: String {
+        get {
+            titleLabel.textString
+        } set {
+            titleLabel.textString = newValue
+        }
+    }
     
     // View
     private let backButton: UIButton = {
@@ -31,24 +37,21 @@ public class NavigationBarType1: UIStackView {
         return btn
     }()
     
-    private lazy var titleText: ResizableUILabel = {
+    private lazy var titleLabel: IdleLabel = {
         
-        let label = ResizableUILabel()
-        
+        let label = IdleLabel(typography: .Subtitle1)
         label.textAlignment = .left
-        label.text = navigationTitle
-        label.font = DSKitFontFamily.Pretendard.semiBold.font(size: 20)
-        
         return label
     }()
     
     private let disposeBag = DisposeBag()
     
     public init(
-        navigationTitle: String
+        navigationTitle: String = ""
     ) {
-        self.navigationTitle = navigationTitle
         super.init(frame: .zero)
+        
+        self.navigationTitle = navigationTitle
         
         setApearance()
         setAutoLayout()
@@ -69,13 +72,13 @@ public class NavigationBarType1: UIStackView {
         
         [
             backButton,
-            titleText,
+            titleLabel,
         ].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             self.addArrangedSubview($0)
         }
         
-        titleText.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         
         backButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Picker/ExpPicker.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Picker/ExpPicker.swift
@@ -140,6 +140,7 @@ extension ExpPicker : UIPickerViewDataSource, UIPickerViewDelegate {
     public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         
         // 라벨 변경
+        currentExp = row
         textLabel.textString = pickerData[row]
         
         // row = 경력연차

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Picker/ExpPicker.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Picker/ExpPicker.swift
@@ -1,0 +1,148 @@
+//
+//  ExpPicker.swift
+//  DSKit
+//
+//  Created by choijunios on 8/10/24.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import Entity
+import PresentationCore
+import FSCalendar
+
+public class ExpPicker: TextImageButtonType2 {
+    
+    static let maxExp = 20
+    
+    private let pickerData: [String] = (0...ExpPicker.maxExp).map { exp in
+        switch exp {
+        case 0:
+            "신입"
+        case 1...ExpPicker.maxExp:
+            "\(exp)년차"
+        default:
+            fatalError()
+        }
+    }
+    
+    public lazy var pickedExp: PublishRelay<Int> = .init()
+    public private(set) var currentExp: Int?
+    
+    // View
+    public lazy var pickerView: UIPickerView = {
+        let view = UIPickerView()
+        view.delegate = self
+        view.dataSource = self
+        return view
+    }()
+    
+    private let disposeBag = DisposeBag()
+    
+    public override var inputView: UIView? {
+        pickerView
+    }
+    
+    public override var inputAccessoryView: UIView? {
+        let toolbar = UIToolbar()
+        toolbar.frame = CGRect(x: 0, y: 0, width: frame.size.width, height: 40)
+        
+        let space = UIBarButtonItem(
+            barButtonSystemItem: .flexibleSpace,
+            target: nil,
+            action: nil
+        )
+        let doneButton = UIBarButtonItem(
+            title: "닫기",
+            style: .done,
+            target: self,
+            action: #selector(didTapDone(_:))
+        )
+        
+        doneButton.tintColor = DSKitAsset.Colors.gray900.color
+        let items = [space, doneButton]
+        toolbar.setItems(items, animated: false)
+        toolbar.sizeToFit()
+        
+        return toolbar
+    }
+    
+    public var placeholderText: String {
+        get {
+            textLabel.textString
+        }
+        set {
+            textLabel.textString = newValue
+        }
+    }
+    
+    public override var canBecomeFirstResponder: Bool { true }
+    
+    public init(placeholderText: String) {
+        super.init()
+        
+        textLabel.textString = placeholderText
+        
+        // 초기값 설정
+        currentExp = 0
+        
+        setObservable()
+    }
+    
+    required init?(coder: NSCoder) { fatalError() }
+    
+    private func setObservable() {
+        self.rx.tap
+            .subscribe { [weak self] _ in
+                self?.didTapButton()
+            }
+            .disposed(by: disposeBag)
+    }
+}
+
+@objc
+extension ExpPicker {
+    /// Close the picker view
+    private func didTapClose(_ button: UIBarButtonItem) {
+        resignFirstResponder()
+    }
+    
+    private func didTapDone(_ button: UIBarButtonItem) {
+        
+        
+        
+        resignFirstResponder()
+    }
+    
+    //MARK: - Open the picker view
+    private func didTapButton() {
+        printIfDebug("CustomPickerButton: button Tap")
+        becomeFirstResponder()
+    }
+    
+}
+
+extension ExpPicker : UIPickerViewDataSource, UIPickerViewDelegate {
+    public func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return pickerData.count
+    }
+    
+    public func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return pickerData[row]
+    }
+    
+    //data 선택시 동작할 event
+    public func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        
+        // 라벨 변경
+        textLabel.textString = pickerData[row]
+        
+        // row = 경력연차
+        pickedExp.accept(row)
+    }
+}

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Picker/ExpPicker.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Picker/ExpPicker.swift
@@ -54,7 +54,7 @@ public class ExpPicker: TextImageButtonType2 {
             action: nil
         )
         let doneButton = UIBarButtonItem(
-            title: "닫기",
+            title: "선택",
             style: .done,
             target: self,
             action: #selector(didTapDone(_:))
@@ -110,7 +110,9 @@ extension ExpPicker {
     
     private func didTapDone(_ button: UIBarButtonItem) {
         
-        
+        // row = 경력연차
+        textLabel.textString = pickerData[currentExp!]
+        pickedExp.accept(currentExp!)
         
         resignFirstResponder()
     }
@@ -141,9 +143,5 @@ extension ExpPicker : UIPickerViewDataSource, UIPickerViewDelegate {
         
         // 라벨 변경
         currentExp = row
-        textLabel.textString = pickerData[row]
-        
-        // row = 경력연차
-        pickedExp.accept(row)
     }
 }

--- a/project/Projects/Presentation/Feature/Base/Sources/View/ViewController/Base/BaseViewController.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/View/ViewController/Base/BaseViewController.swift
@@ -13,9 +13,11 @@ open class BaseViewController: UIViewController { }
 // MARK: Alert
 public extension BaseViewController {
     
-    func showAlert(vo: DefaultAlertContentVO) {
+    func showAlert(vo: DefaultAlertContentVO, onClose: (() -> ())? = nil) {
         let alret = UIAlertController(title: vo.title, message: vo.message, preferredStyle: .alert)
-        let close = UIAlertAction(title: "닫기", style: .default, handler: nil)
+        let close = UIAlertAction(title: "닫기", style: .default) { _ in
+            onClose?()
+        }
         alret.addAction(close)
         present(alret, animated: true, completion: nil)
     }

--- a/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
+++ b/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
@@ -20,11 +20,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let vm = WorkerMyProfileViewModel()
         
+        
         let vc = WorkerProfileViewController()
         
         vc.bind(vm)
         
-        window?.rootViewController = vc
+        let nav = UINavigationController(rootViewController: vc)
+        nav.setNavigationBarHidden(true, animated: false)
+        
+        window?.rootViewController = nav
         window?.makeKeyAndVisible()
     }
 }

--- a/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
+++ b/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
@@ -6,7 +6,10 @@
 //
 
 import UIKit
+import ConcreteUseCase
+import ConcreteRepository
 import WorkerFeature
+import NetworkDataSource
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -18,8 +21,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         self.window = UIWindow(windowScene: windowScene)
         
-        let vm = WorkerMyProfileViewModel()
+        let store = TestStore()
         
+        try! store.saveAuthToken(
+            accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOm51bGwsInN1YiI6bnVsbCwiaXNzIjoiM2lkaW90cyIsImlhdCI6MTcyMzI4MjA5MSwibmJmIjoxNzIzMjgyMDkxLCJleHAiOjE3MjMyODI2OTEsInR5cGUiOiJBQ0NFU1NfVE9LRU4iLCJ1c2VySWQiOiIwMTkxM2I5ZC1lZTJiLTc4NjQtOWMxNC0zMDYzNDcwODViNzgiLCJwaG9uZU51bWJlciI6IjAxMC02NjY2LTU2NzgiLCJ1c2VyVHlwZSI6ImNhcmVyIn0.ugfPnQAR-B_AlhIor3BNGjaVZ5IAsSPqG1puH_kQRMc",
+            refreshToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOm51bGwsInN1YiI6bnVsbCwiaXNzIjoiM2lkaW90cyIsImlhdCI6MTcyMzI4MjA5MSwibmJmIjoxNzIzMjgyMDkxLCJleHAiOjE3Mzg4MzQwOTEsInR5cGUiOiJSRUZSRVNIX1RPS0VOIiwidXNlcklkIjoiMDE5MTNiOWQtZWUyYi03ODY0LTljMTQtMzA2MzQ3MDg1Yjc4IiwidXNlclR5cGUiOiJjYXJlciJ9.2NETtfIGn8KX9XiEDqH_QqgagNXpHmu3wOsNUPix2p0"
+        )
+        
+        let useCase = DefaultWorkerProfileUseCase(
+            repository: DefaultUserProfileRepository()
+        )
+        
+        let vm = WorkerMyProfileViewModel(workerProfileUseCase: useCase)
         
         let vc = WorkerProfileViewController()
         
@@ -31,4 +44,24 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.rootViewController = nav
         window?.makeKeyAndVisible()
     }
+}
+
+
+class TestStore: KeyValueStore {
+    func save(key: String, value: String) throws {
+        UserDefaults.standard.setValue(value, forKey: key)
+    }
+    
+    func get(key: String) -> String? {
+        UserDefaults.standard.string(forKey: key)
+    }
+    
+    func delete(key: String) throws {
+        
+    }
+    
+    func removeAll() throws {
+        
+    }
+    
 }

--- a/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
+++ b/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
@@ -24,12 +24,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let store = TestStore()
         
         try! store.saveAuthToken(
-            accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOm51bGwsInN1YiI6bnVsbCwiaXNzIjoiM2lkaW90cyIsImlhdCI6MTcyMzI4MjA5MSwibmJmIjoxNzIzMjgyMDkxLCJleHAiOjE3MjMyODI2OTEsInR5cGUiOiJBQ0NFU1NfVE9LRU4iLCJ1c2VySWQiOiIwMTkxM2I5ZC1lZTJiLTc4NjQtOWMxNC0zMDYzNDcwODViNzgiLCJwaG9uZU51bWJlciI6IjAxMC02NjY2LTU2NzgiLCJ1c2VyVHlwZSI6ImNhcmVyIn0.ugfPnQAR-B_AlhIor3BNGjaVZ5IAsSPqG1puH_kQRMc",
-            refreshToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOm51bGwsInN1YiI6bnVsbCwiaXNzIjoiM2lkaW90cyIsImlhdCI6MTcyMzI4MjA5MSwibmJmIjoxNzIzMjgyMDkxLCJleHAiOjE3Mzg4MzQwOTEsInR5cGUiOiJSRUZSRVNIX1RPS0VOIiwidXNlcklkIjoiMDE5MTNiOWQtZWUyYi03ODY0LTljMTQtMzA2MzQ3MDg1Yjc4IiwidXNlclR5cGUiOiJjYXJlciJ9.2NETtfIGn8KX9XiEDqH_QqgagNXpHmu3wOsNUPix2p0"
+            accessToken: "",
+            refreshToken: ""
         )
         
         let useCase = DefaultWorkerProfileUseCase(
-            repository: DefaultUserProfileRepository()
+            repository: DefaultUserProfileRepository(store)
         )
         
         let vm = WorkerMyProfileViewModel(workerProfileUseCase: useCase)

--- a/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
+++ b/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         self.window = UIWindow(windowScene: windowScene)
         
-        let vm = WorkerProfileViewModel()
+        let vm = WorkerMyProfileViewModel()
         
         let vc = WorkerProfileViewController()
         

--- a/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
+++ b/project/Projects/Presentation/Feature/Worker/ExampleApp/Sources/SceneDelegate.swift
@@ -24,7 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let store = TestStore()
         
         try! store.saveAuthToken(
-            accessToken: "",
+            accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOm51bGwsInN1YiI6bnVsbCwiaXNzIjoiM2lkaW90cyIsImlhdCI6MTcyMzI5NzQyOCwibmJmIjoxNzIzMjk3NDI4LCJleHAiOjE3MjMyOTgwMjgsInR5cGUiOiJBQ0NFU1NfVE9LRU4iLCJ1c2VySWQiOiIwMTkxM2M4Ny1mMjMxLTdmMDctYTNjYS1jYTJhNjk4OTExZWQiLCJwaG9uZU51bWJlciI6IjAxMC0zMzI2LTU2NzgiLCJ1c2VyVHlwZSI6ImNhcmVyIn0.R_obT8lFGxf2jeDhrpC0aLntwDslI-NYoEbyEZLwhZ0",
             refreshToken: ""
         )
         

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/RenderObject/WorkerProfileRenderObject.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/RenderObject/WorkerProfileRenderObject.swift
@@ -16,6 +16,7 @@ public struct WorkerProfileRenderObject {
     let isJobFinding: Bool
     let stateText: String
     let nameText: String
+    let phoneNumber: String
     let ageText: String
     let genderText: String
     let expText: String
@@ -32,6 +33,7 @@ public struct WorkerProfileRenderObject {
             isJobFinding: vo.isLookingForJob,
             stateText: vo.isLookingForJob ? "구인중" : "휴식중",
             nameText: vo.nameText,
+            phoneNumber: "010-4444-555",
             ageText: "\(vo.age)세",
             genderText: vo.gender.twoLetterKoreanWord,
             expText: vo.expYear == nil ? "신입" : "\(vo.expYear!)년차",

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/RenderObject/WorkerProfileRenderObject.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/RenderObject/WorkerProfileRenderObject.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  WorkerFeature
+//
+//  Created by choijunios on 8/10/24.
+//
+
+import Foundation
+import Entity
+
+// MARK: RO
+public struct WorkerProfileRenderObject {
+    
+    let navigationTitle: String
+    let showEditButton: Bool
+    let isJobFinding: Bool
+    let stateText: String
+    let nameText: String
+    let ageText: String
+    let genderText: String
+    let expText: String
+    let address: String
+    let oneLineIntroduce: String
+    let specialty: String
+    let imageUrl: URL?
+    
+    static func createRO(isMyProfile: Bool, vo: WorkerProfileVO) -> WorkerProfileRenderObject {
+        
+        .init(
+            navigationTitle: isMyProfile ? "내 프로필" : "요양보호사 프로필",
+            showEditButton: isMyProfile,
+            isJobFinding: vo.isLookingForJob,
+            stateText: vo.isLookingForJob ? "구인중" : "휴식중",
+            nameText: vo.nameText,
+            ageText: "\(vo.age)세",
+            genderText: vo.gender.twoLetterKoreanWord,
+            expText: vo.expYear == nil ? "신입" : "\(vo.expYear!)년차",
+            address: vo.address.roadAddress,
+            oneLineIntroduce: vo.introductionText,
+            specialty: vo.specialty,
+            imageUrl: URL(string: vo.profileImageURL ?? "")
+        )
+    }
+}

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/RenderObject/WorkerProfileRenderObject.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/RenderObject/WorkerProfileRenderObject.swift
@@ -33,7 +33,7 @@ public struct WorkerProfileRenderObject {
             isJobFinding: vo.isLookingForJob,
             stateText: vo.isLookingForJob ? "구인중" : "휴식중",
             nameText: vo.nameText,
-            phoneNumber: "010-4444-555",
+            phoneNumber: vo.phoneNumber,
             ageText: "\(vo.age)세",
             genderText: vo.gender.twoLetterKoreanWord,
             expText: vo.expYear == nil ? "신입" : "\(vo.expYear!)년차",

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
@@ -14,7 +14,7 @@ import Entity
 import BaseFeature
 
 
-public class EditWorkerProfileViewController: DisposableViewController {
+public class EditWorkerProfileViewController: BaseViewController {
     
     // Navigation bar
     let navigationBar: NavigationBarType1 = {
@@ -50,14 +50,16 @@ public class EditWorkerProfileViewController: DisposableViewController {
 
         return view
     }()
-    let workerProfileDisplayingImage: UIImageView = {
+    let workerProfileImage: UIImageView = {
         
         let imageView = UIImageView()
         imageView.layer.cornerRadius = 48
         imageView.contentMode = .scaleAspectFit
         imageView.clipsToBounds = true
+        
         return imageView
     }()
+    
     let workerProfileImageEditButton: UIButton = {
         let btn = UIButton()
         btn.setImage(DSKitAsset.Icons.editPhoto.image, for: .normal)
@@ -67,6 +69,20 @@ public class EditWorkerProfileViewController: DisposableViewController {
         btn.isUserInteractionEnabled = true
         return btn
     }()
+    
+    // 상태 선택 버튼
+    let stateSelectButton: SlideStateButton = {
+        let button: SlideStateButton = .init(initialState: .state1)
+        button.state1Label.textString = "휴식중"
+        button.state2Label.textString = "구인중"
+        return button
+    }()
+    
+    // 이름, 나이, 성별, 전화번호
+    let nameLabel: IdleLabel = .init(typography: .Subtitle1)
+    let ageLabel: IdleLabel = .init(typography: .Body3)
+    let genderLabel: IdleLabel = .init(typography: .Body3)
+    let phoneNumberLabel: IdleLabel = .init(typography: .Body3)
     
     // 경력
     let experiencedSelectButton: ExpPicker = {
@@ -110,6 +126,9 @@ public class EditWorkerProfileViewController: DisposableViewController {
     }()
     
     let disposeBag = DisposeBag()
+    
+    // Optinal values
+    public var onError: (()->())?
     
     public init() {
         
@@ -156,26 +175,105 @@ public class EditWorkerProfileViewController: DisposableViewController {
         ])
         
         // 프로필 뷰
-        [
-            workerProfileDisplayingImage
-        ].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            profileImageContainer.addSubview($0)
-        }
+        
+        // 유저의 입력으로 설정되는 사진을 표시하는 ImageView설정
+        profileImageContainer.addSubview(workerProfileImage)
+        workerProfileImage.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            workerProfileDisplayingImage.topAnchor.constraint(equalTo: profileImageContainer.topAnchor),
-            workerProfileDisplayingImage.leadingAnchor.constraint(equalTo: profileImageContainer.leadingAnchor),
-            workerProfileDisplayingImage.trailingAnchor.constraint(equalTo: profileImageContainer.trailingAnchor),
-            workerProfileDisplayingImage.bottomAnchor.constraint(equalTo: profileImageContainer.bottomAnchor),
+            workerProfileImage.topAnchor.constraint(equalTo: profileImageContainer.topAnchor),
+            workerProfileImage.leadingAnchor.constraint(equalTo: profileImageContainer.leadingAnchor),
+            workerProfileImage.trailingAnchor.constraint(equalTo: profileImageContainer.trailingAnchor),
+            workerProfileImage.bottomAnchor.constraint(equalTo: profileImageContainer.bottomAnchor),
         ])
         
+        let profileContainer = UIView()
+        [
+            profileImageContainer,
+            workerProfileImageEditButton
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            profileContainer.addSubview($0)
+        }
+        NSLayoutConstraint.activate([
+            profileImageContainer.widthAnchor.constraint(equalToConstant: 96),
+            profileImageContainer.heightAnchor.constraint(equalTo: profileImageContainer.widthAnchor),
+            
+            profileImageContainer.topAnchor.constraint(equalTo: profileContainer.topAnchor),
+            profileImageContainer.leadingAnchor.constraint(equalTo: profileContainer.leadingAnchor),
+            profileImageContainer.trailingAnchor.constraint(equalTo: profileContainer.trailingAnchor),
+            profileImageContainer.bottomAnchor.constraint(equalTo: profileContainer.bottomAnchor),
+            
+            workerProfileImageEditButton.widthAnchor.constraint(equalToConstant: 32),
+            workerProfileImageEditButton.heightAnchor.constraint(equalTo: workerProfileImageEditButton.widthAnchor),
+            
+            workerProfileImageEditButton.bottomAnchor.constraint(equalTo: profileContainer.bottomAnchor),
+            workerProfileImageEditButton.trailingAnchor.constraint(equalTo: profileContainer.trailingAnchor, constant: 7),
+        ])
         
-        // // 요양보호사 인적정보 / 요양보호사 구직정보 디바이더
-        let divider = UIView()
-        divider.backgroundColor = DSKitAsset.Colors.gray050.color
+        // 나이, 성별, 전화번호 컨테이너
+        let infoStack_divider1 = UIView()
+        infoStack_divider1.backgroundColor = DSKitAsset.Colors.gray050.color
+        let infoStack_divider2 = UIView()
+        infoStack_divider2.backgroundColor = DSKitAsset.Colors.gray050.color
+        
+        let infoStackViews = [
+            ("나이", ageLabel),
+            ("성별", genderLabel),
+            ("전화번호", phoneNumberLabel),
+        ].map({ (title, labelView) in
+            
+            let titleLabel = IdleLabel(typography: .Body3)
+            titleLabel.textString = title
+            titleLabel.attrTextColor = DSKitAsset.Colors.gray500.color
+            
+            return HStack([
+                titleLabel,
+                labelView
+            ], spacing: 4)
+        })
+        
+        let infoStack = HStack(
+            [
+                infoStackViews[0],
+                infoStack_divider1,
+                infoStackViews[1],
+                infoStack_divider2,
+                infoStackViews[2],
+            ],
+            spacing: 8
+        )
+        
+        NSLayoutConstraint.activate([
+            infoStack_divider1.widthAnchor.constraint(equalToConstant: 1),
+            infoStack_divider1.topAnchor.constraint(equalTo: infoStack.topAnchor, constant: 2),
+            infoStack_divider1.bottomAnchor.constraint(equalTo: infoStack.bottomAnchor, constant: -2),
+            
+            infoStack_divider2.widthAnchor.constraint(equalToConstant: 1),
+            infoStack_divider2.topAnchor.constraint(equalTo: infoStack.topAnchor, constant: 2),
+            infoStack_divider2.bottomAnchor.constraint(equalTo: infoStack.bottomAnchor, constant: -2),
+        ])
+        
+        let viewList = [
+            profileContainer,
+            Spacer(height: 12),
+            nameLabel,
+            Spacer(height: 6),
+            stateSelectButton,
+            Spacer(height: 16),
+            infoStack,
+        ]
+        
+        let profileAndInfoStack = VStack(
+            viewList,
+            spacing: 0,
+            alignment: .center
+        )
         
         // 경력, 주소, 한줄소개, 특기
-        let addressIntroductionAbilityStack = VStack(
+        let addtionalInfoView = UIView()
+        addtionalInfoView.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 20)
+        
+        let addtionalInfoStack = VStack(
             [
                 ("경력", experiencedSelectButton),
                 ("주소", addressInputField),
@@ -201,16 +299,53 @@ public class EditWorkerProfileViewController: DisposableViewController {
             alignment: .fill
         )
         
-        // 컨트롤러 뷰 설정
-        let scrollView = {
-            let view = UIScrollView()
-            // 발생한 터치가 스크롤인지 판단하지 않고 즉시 touchShouldBegin매서드를 호출한다.
-            // true시 탭동작을 스크롤로 판단한다.
-            view.delaysContentTouches = false
-            return view
-        }()
+        [
+            addtionalInfoStack
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            addtionalInfoView.addSubview($0)
+        }
         
-        let scrollViewContentGuide = scrollView.contentLayoutGuide
+        NSLayoutConstraint.activate([
+            addtionalInfoStack.topAnchor.constraint(equalTo: addtionalInfoView.layoutMarginsGuide.topAnchor),
+            addtionalInfoStack.leftAnchor.constraint(equalTo: addtionalInfoView.layoutMarginsGuide.leftAnchor),
+            addtionalInfoStack.rightAnchor.constraint(equalTo: addtionalInfoView.layoutMarginsGuide.rightAnchor),
+            addtionalInfoStack.bottomAnchor.constraint(equalTo: addtionalInfoView.layoutMarginsGuide.bottomAnchor),
+        ])
+        
+        // 컨트롤러 뷰 설정
+        let scrollView = UIScrollView()
+        scrollView.delaysContentTouches = false
+        scrollView.contentInset = .init(top: 39, left: 0, bottom: 66, right: 0)
+        
+        let contentGuide = scrollView.contentLayoutGuide
+        let frameGuide = scrollView.frameLayoutGuide
+        
+        
+        
+        let divier = UIView()
+        divier.backgroundColor = DSKitAsset.Colors.gray050.color
+        
+        let contentView = VStack([profileAndInfoStack, divier, addtionalInfoView], spacing: 20, alignment: .fill)
+        
+        [
+            contentView
+        ].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            scrollView.addSubview($0)
+        }
+        
+        NSLayoutConstraint.activate([
+            divier.heightAnchor.constraint(equalToConstant: 8),
+            
+            contentView.widthAnchor.constraint(equalTo: frameGuide.widthAnchor),
+            
+            contentView.topAnchor.constraint(equalTo: contentGuide.topAnchor),
+            contentView.leftAnchor.constraint(equalTo: contentGuide.leftAnchor),
+            contentView.rightAnchor.constraint(equalTo: contentGuide.rightAnchor),
+            contentView.bottomAnchor.constraint(equalTo: contentGuide.bottomAnchor),
+        ])
+        
         
         [
             navigationStackBackground,
@@ -230,44 +365,6 @@ public class EditWorkerProfileViewController: DisposableViewController {
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
-        
-        // Scroll View
-        [
-            profileImageContainer,
-            divider,
-            addressIntroductionAbilityStack
-        ].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-            scrollView.addSubview($0)
-        }
-        
-        scrollView.insertSubview(workerProfileImageEditButton, aboveSubview: profileImageContainer)
-        workerProfileImageEditButton.translatesAutoresizingMaskIntoConstraints = false
-        
-        NSLayoutConstraint.activate([
-            
-            workerProfileImageEditButton.widthAnchor.constraint(equalToConstant: 32),
-            workerProfileImageEditButton.heightAnchor.constraint(equalTo: workerProfileImageEditButton.widthAnchor),
-            workerProfileImageEditButton.bottomAnchor.constraint(equalTo: profileImageContainer.bottomAnchor),
-            workerProfileImageEditButton.trailingAnchor.constraint(equalTo: profileImageContainer.trailingAnchor, constant: 7),
-            
-            profileImageContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            profileImageContainer.topAnchor.constraint(equalTo: scrollViewContentGuide.topAnchor, constant: 40),
-            
-            divider.topAnchor.constraint(equalTo: profileImageContainer.bottomAnchor, constant: 24),
-            divider.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            divider.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            divider.heightAnchor.constraint(equalToConstant: 8),
-            
-            addressIntroductionAbilityStack.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 24),
-            addressIntroductionAbilityStack.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
-            addressIntroductionAbilityStack.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            addressIntroductionAbilityStack.bottomAnchor.constraint(
-                equalTo: scrollViewContentGuide.bottomAnchor, constant: -28.37),
-            
-            abilityInputField.heightAnchor.constraint(equalToConstant: 156)
-        ])
-        
     }
     
     private func setObservable() {
@@ -278,12 +375,33 @@ public class EditWorkerProfileViewController: DisposableViewController {
                 self?.dismiss(animated: true)
             })
             .disposed(by: disposeBag)
-        
-        
     }
+}
+
+extension EditWorkerProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     
-    public func cleanUp() {
+    private func showPhotoGalley() {
         
+        let imagePickerVC = UIImagePickerController()
+        imagePickerVC.delegate = self
+        
+        if !UIImagePickerController.isSourceTypeAvailable(.photoLibrary) {
+            onError?()
+            return
+        }
+        
+        imagePickerVC.sourceType = .photoLibrary
+        self.present(imagePickerVC, animated: true)
     }
-    
+        
+    public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+     
+        if let imageUrl = info[UIImagePickerController.InfoKey.imageURL] as? UIImage {
+            
+            // image
+            
+            
+            picker.dismiss(animated: true)
+        }
+    }
 }

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
@@ -68,54 +68,16 @@ public class EditWorkerProfileViewController: DisposableViewController {
         return btn
     }()
     
-    // 이름
-    let nameInputField: MultiLineTextField = {
-        let textView = MultiLineTextField(
-            typography: .Body3,
-            placeholderText: "성함"
-        )
-        textView.textContainerInset = .init(top: 10, left: 16, bottom: 10, right: 24)
-        textView.isScrollEnabled = false
-        
-        return textView
-    }()
-    
-    // 성별
-    let femaleButton: StateButtonTyp1 = {
-        let btn = StateButtonTyp1(
-            text: Gender.female.twoLetterKoreanWord,
-            initial: .normal
-        )
-        return btn
-    }()
-    let maleButton: StateButtonTyp1 = {
-        let btn = StateButtonTyp1(
-            text: Gender.male.twoLetterKoreanWord,
-            initial: .normal
-        )
-        return btn
-    }()
-    
-    // 나이
-    let ageInputField: IdleTextField = {
-        let field = IdleTextField(typography: .Body2)
-        field.keyboardType = .numberPad
-        return field
-    }()
-    
     // 경력
-    let expLabel: IdleLabel = {
-        let label = IdleLabel(typography: .Body2)
-        label.attrTextColor = DSKitAsset.Colors.gray500.color
-        return label
+    let experiencedSelectButton: ExpPicker = {
+        let button = ExpPicker(placeholderText: "연차")
+        
+        button.textLabel.attrTextColor = DSKitAsset.Colors.gray500.color
+        button.imageView.image = DSKitAsset.Icons.chevronDown.image
+        button.imageView.tintColor = DSKitAsset.Colors.gray200.color
+        
+        return button
     }()
-    let expEditButton: UIButton = {
-        let btn = UIButton()
-        btn.setImage(DSKitAsset.Icons.chevronDown.image, for: .normal)
-        btn.isUserInteractionEnabled = true
-        return btn
-    }()
-    
     
     // 주소
     let addressInputField: MultiLineTextField = {
@@ -123,7 +85,6 @@ public class EditWorkerProfileViewController: DisposableViewController {
             typography: .Body3,
             placeholderText: "주소"
         )
-        textView.textContainerInset = .init(top: 10, left: 16, bottom: 10, right: 24)
         textView.isScrollEnabled = false
         return textView
     }()
@@ -134,7 +95,6 @@ public class EditWorkerProfileViewController: DisposableViewController {
             typography: .Body3,
             placeholderText: "소개"
         )
-        textView.textContainerInset = .init(top: 10, left: 16, bottom: 10, right: 24)
         textView.isScrollEnabled = false
         return textView
     }()
@@ -145,7 +105,6 @@ public class EditWorkerProfileViewController: DisposableViewController {
             typography: .Body3,
             placeholderText: "특기"
         )
-        textView.textContainerInset = .init(top: 12, left: 16, bottom: 16, right: 22)
         textView.isScrollEnabled = false
         return textView
     }()
@@ -183,6 +142,7 @@ public class EditWorkerProfileViewController: DisposableViewController {
         ])
         navigationStack.distribution = .equalSpacing
         navigationStack.backgroundColor = .white
+        
         let navigationStackBackground = UIView()
         navigationStackBackground.addSubview(navigationStack)
         navigationStack.translatesAutoresizingMaskIntoConstraints = false
@@ -209,146 +169,15 @@ public class EditWorkerProfileViewController: DisposableViewController {
             workerProfileDisplayingImage.bottomAnchor.constraint(equalTo: profileImageContainer.bottomAnchor),
         ])
         
-        // 나이
-        let ageInputContainer = HStack(
-            [
-               ageInputField,
-               {
-                   let label = IdleLabel(typography: .Body3)
-                   label.textString = "세"
-                   return label
-               }()
-            ],
-            alignment: .center,
-            distribution: .equalSpacing
-        )
-        let ageInputContainerBackground = {
-            let view = UIView()
-            view.backgroundColor = .clear
-            view.layoutMargins = .init(top: 10, left: 16, bottom: 10, right: 15.5)
-            view.layer.borderColor = DSKitAsset.Colors.gray100.color.cgColor
-            view.layer.borderWidth = 1.0
-            view.layer.cornerRadius = 6.0
-            return view
-        }()
-        ageInputContainerBackground.addSubview(ageInputContainer)
-        ageInputContainer.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            // 명시적 높이 지정
-            ageInputContainer.heightAnchor.constraint(equalToConstant: 24),
-            
-            ageInputContainer.topAnchor.constraint(equalTo: ageInputContainerBackground.layoutMarginsGuide.topAnchor),
-            ageInputContainer.bottomAnchor.constraint(equalTo: ageInputContainerBackground.layoutMarginsGuide.bottomAnchor),
-            ageInputContainer.leadingAnchor.constraint(equalTo: ageInputContainerBackground.layoutMarginsGuide.leadingAnchor),
-            ageInputContainer.trailingAnchor.constraint(equalTo: ageInputContainerBackground.layoutMarginsGuide.trailingAnchor),
-        ])
-        
-        // 경력
-        let expInputContainer = HStack(
-            [
-               expLabel,
-               expEditButton
-            ],
-            alignment: .center,
-            distribution: .equalSpacing
-        )
-        let expInputContainerBackground = {
-            let view = UIView()
-            view.backgroundColor = .clear
-            view.layoutMargins = .init(top: 10, left: 16, bottom: 10, right: 15.5)
-            view.layer.borderColor = DSKitAsset.Colors.gray100.color.cgColor
-            view.layer.borderWidth = 1.0
-            view.layer.cornerRadius = 6.0
-            return view
-        }()
-        expInputContainerBackground.addSubview(expInputContainer)
-        expInputContainer.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            // 명시적 높이 지정
-            expInputContainer.heightAnchor.constraint(equalToConstant: 24),
-            
-            expInputContainer.topAnchor.constraint(equalTo: expInputContainerBackground.layoutMarginsGuide.topAnchor),
-            expInputContainer.bottomAnchor.constraint(equalTo: expInputContainerBackground.layoutMarginsGuide.bottomAnchor),
-            expInputContainer.leadingAnchor.constraint(equalTo: expInputContainerBackground.layoutMarginsGuide.leadingAnchor),
-            expInputContainer.trailingAnchor.constraint(equalTo: expInputContainerBackground.layoutMarginsGuide.trailingAnchor),
-        ])
- 
-        // 나이+경력
-        let ageExpStack = HStack(
-            [
-                ("나이", ageInputContainerBackground),
-                ("경력", expInputContainerBackground)
-            ].map { (title, content) in
-                
-                VStack(
-                    [
-                        {
-                            let label = IdleLabel(typography: .Subtitle4)
-                            label.textString = title
-                            label.attrTextColor = DSKitAsset.Colors.gray300.color
-                            label.textAlignment = .left
-                            return label
-                        }(),
-                        content
-                    ],
-                    spacing: 6,
-                    alignment: .fill
-                )
-            }
-            , spacing: 4,
-            distribution: .fillEqually
-        )
-        
-        // 성별
-        let genderStack = VStack(
-            [
-                {
-                    let label = IdleLabel(typography: .Subtitle4)
-                    label.textString = "성별"
-                    label.attrTextColor = DSKitAsset.Colors.gray300.color
-                    return label
-                }(),
-                HStack(
-                    [
-                        femaleButton,
-                        maleButton
-                    ].map { btn in
-                        NSLayoutConstraint.activate([
-                            btn.widthAnchor.constraint(equalToConstant: 104),
-                            btn.heightAnchor.constraint(equalToConstant: 44),
-                        ])
-                        return btn
-                    },
-                    spacing: 4
-                )
-            ],
-            spacing: 6,
-            alignment: .leading
-        )
-        
-        // 이름
-        let nameStack = VStack(
-            [
-                {
-                    let label = IdleLabel(typography: .Subtitle4)
-                    label.textString = "이름"
-                    label.attrTextColor = DSKitAsset.Colors.gray300.color
-                    label.textAlignment = .left
-                    return label
-                }(),
-                nameInputField
-            ],
-            spacing: 6,
-            alignment: .fill
-        )
         
         // // 요양보호사 인적정보 / 요양보호사 구직정보 디바이더
         let divider = UIView()
         divider.backgroundColor = DSKitAsset.Colors.gray050.color
         
-        // 주소 + 소개 + 특기
+        // 경력, 주소, 한줄소개, 특기
         let addressIntroductionAbilityStack = VStack(
             [
+                ("경력", experiencedSelectButton),
                 ("주소", addressInputField),
                 ("한줄 소개", introductionInputField),
                 ("특기", abilityInputField),
@@ -405,9 +234,6 @@ public class EditWorkerProfileViewController: DisposableViewController {
         // Scroll View
         [
             profileImageContainer,
-            nameStack,
-            genderStack,
-            ageExpStack,
             divider,
             addressIntroductionAbilityStack
         ].forEach {
@@ -428,19 +254,7 @@ public class EditWorkerProfileViewController: DisposableViewController {
             profileImageContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             profileImageContainer.topAnchor.constraint(equalTo: scrollViewContentGuide.topAnchor, constant: 40),
             
-            nameStack.topAnchor.constraint(equalTo: profileImageContainer.bottomAnchor, constant: 19),
-            nameStack.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
-            nameStack.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            
-            genderStack.topAnchor.constraint(equalTo: nameStack.bottomAnchor, constant: 24),
-            genderStack.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
-            genderStack.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            
-            ageExpStack.topAnchor.constraint(equalTo: genderStack.bottomAnchor, constant: 28),
-            ageExpStack.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
-            ageExpStack.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
-            
-            divider.topAnchor.constraint(equalTo: ageExpStack.bottomAnchor, constant: 24),
+            divider.topAnchor.constraint(equalTo: profileImageContainer.bottomAnchor, constant: 24),
             divider.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             divider.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             divider.heightAnchor.constraint(equalToConstant: 8),
@@ -464,6 +278,8 @@ public class EditWorkerProfileViewController: DisposableViewController {
                 self?.dismiss(animated: true)
             })
             .disposed(by: disposeBag)
+        
+        
     }
     
     public func cleanUp() {

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
@@ -420,6 +420,7 @@ public class EditWorkerProfileViewController: BaseViewController {
                 navigationBar.navigationTitle = ro.navigationTitle
                 stateSelectButton.setState(ro.isJobFinding ? jobFindingState : restingState)
                 nameLabel.textString = ro.nameText
+                phoneNumberLabel.textString = ro.phoneNumber
                 ageLabel.textString = ro.ageText
                 genderLabel.textString = ro.genderText
                 experiencedSelectButton.textLabel.textString = ro.expText
@@ -433,12 +434,21 @@ public class EditWorkerProfileViewController: BaseViewController {
             })
             .disposed(by: disposeBag)
         
+        // 수정 실패 수신
         viewModel
             .alert?
             .drive(onNext: { [weak self] vo in
                 self?.showAlert(vo: vo) { [weak self] in
                     self?.navigationController?.popViewController(animated: true)
                 }
+            })
+            .disposed(by: disposeBag)
+        
+        // 수정 성공 여부 수신
+        viewModel
+            .uploadSuccess?
+            .drive(onNext: { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
             })
             .disposed(by: disposeBag)
         

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
@@ -102,6 +102,12 @@ public class EditWorkerProfileViewController: BaseViewController {
     let phoneNumberLabel: IdleLabel = .init(typography: .Body3)
     
     // 경력
+    let addtionalInfoView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
     let experiencedSelectButton: ExpPicker = {
         let button = ExpPicker(placeholderText: "연차")
         
@@ -153,6 +159,7 @@ public class EditWorkerProfileViewController: BaseViewController {
         setApearance()
         setAutoLayout()
         setObservable()
+        setKeyboardAvoidance()
     }
     
     public required init?(coder: NSCoder) {
@@ -286,7 +293,6 @@ public class EditWorkerProfileViewController: BaseViewController {
         )
         
         // 경력, 주소, 한줄소개, 특기
-        let addtionalInfoView = UIView()
         addtionalInfoView.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 20)
         
         let addtionalInfoStack = VStack(
@@ -498,6 +504,16 @@ public class EditWorkerProfileViewController: BaseViewController {
             .eventPublisher
             .bind(to: viewModel.requestUpload)
             .disposed(by: disposeBag)
+    }
+    
+    func setKeyboardAvoidance() {
+        
+         [
+            introductionInputField.setKeyboardAvoidance,
+            abilityInputField.setKeyboardAvoidance,
+         ].forEach { setFunc in
+             setFunc(addtionalInfoView)
+         }
     }
 }
 

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
@@ -12,7 +12,7 @@ import RxCocoa
 import DSKit
 import Entity
 import BaseFeature
-
+import Kingfisher
 
 public class EditWorkerProfileViewController: BaseViewController {
     
@@ -38,6 +38,7 @@ public class EditWorkerProfileViewController: BaseViewController {
         view.layer.cornerRadius = 48
         view.clipsToBounds = true
         
+        /// PlaceHolderImage
         let imageView = DSKitAsset.Icons.workerProfilePlaceholder.image.toView()
         view.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -54,7 +55,7 @@ public class EditWorkerProfileViewController: BaseViewController {
         
         let imageView = UIImageView()
         imageView.layer.cornerRadius = 48
-        imageView.contentMode = .scaleAspectFit
+        imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         
         return imageView
@@ -375,6 +376,13 @@ public class EditWorkerProfileViewController: BaseViewController {
                 self?.dismiss(animated: true)
             })
             .disposed(by: disposeBag)
+        
+        workerProfileImageEditButton
+            .rx.tap
+            .subscribe(onNext: { [weak self] _ in
+                self?.showPhotoGalley()
+            })
+            .disposed(by: disposeBag)
     }
 }
 
@@ -396,10 +404,11 @@ extension EditWorkerProfileViewController: UIImagePickerControllerDelegate, UINa
         
     public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
      
-        if let imageUrl = info[UIImagePickerController.InfoKey.imageURL] as? UIImage {
+        if let imageUrl = info[UIImagePickerController.InfoKey.imageURL] as? URL {
             
-            // image
+            let pngSerializer = FormatIndicatedCacheSerializer.png
             
+            workerProfileImage.setImage(url: imageUrl)
             
             picker.dismiss(animated: true)
         }

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/EditWorkerProfileViewController.swift
@@ -333,6 +333,8 @@ public class EditWorkerProfileViewController: BaseViewController {
             addtionalInfoStack.leftAnchor.constraint(equalTo: addtionalInfoView.layoutMarginsGuide.leftAnchor),
             addtionalInfoStack.rightAnchor.constraint(equalTo: addtionalInfoView.layoutMarginsGuide.rightAnchor),
             addtionalInfoStack.bottomAnchor.constraint(equalTo: addtionalInfoView.layoutMarginsGuide.bottomAnchor),
+            
+            abilityInputField.heightAnchor.constraint(equalToConstant: 156),
         ])
         
         // 컨트롤러 뷰 설정

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/WorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/WorkerProfileViewController.swift
@@ -413,3 +413,9 @@ public class WorkerProfileViewController: DisposableViewController {
         
     }
 }
+
+@available(iOS 17.0, *)
+#Preview("Preview", traits: .defaultLayout) {
+    
+    WorkerProfileViewController()
+}

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/WorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/WorkerProfileViewController.swift
@@ -290,6 +290,9 @@ public class WorkerProfileViewController: DisposableViewController {
         
         
         // 요양보호사 구직정보
+        let employeeInfoTitleLabel = IdleLabel(typography: .Subtitle1)
+        employeeInfoTitleLabel.textString = "상세 정보"
+        employeeInfoTitleLabel.textAlignment = .left
         
         let employeeInfoStack = VStack(
             [
@@ -318,6 +321,7 @@ public class WorkerProfileViewController: DisposableViewController {
             tagNameStack,
             humanInfoStack,
             divider,
+            employeeInfoTitleLabel,
             employeeInfoStack
             
         ].forEach {
@@ -354,7 +358,10 @@ public class WorkerProfileViewController: DisposableViewController {
             divider.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             divider.heightAnchor.constraint(equalToConstant: 8),
             
-            employeeInfoStack.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 24),
+            employeeInfoTitleLabel.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 24),
+            employeeInfoTitleLabel.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+            
+            employeeInfoStack.topAnchor.constraint(equalTo: employeeInfoTitleLabel.bottomAnchor, constant: 20),
             employeeInfoStack.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
             employeeInfoStack.trailingAnchor.constraint(equalTo: view.layoutMarginsGuide.trailingAnchor),
         ])

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/profile/WorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/profile/WorkerProfileViewController.swift
@@ -53,6 +53,7 @@ public class WorkerProfileViewController: DisposableViewController {
         button.label.attrTextColor = DSKitAsset.Colors.gray300.color
         button.layoutMargins = .init(top: 5.5, left:12, bottom: 5.5, right: 12)
         button.layer.cornerRadius = 16
+        button.isHidden = true
         return button
     }()
     
@@ -192,7 +193,6 @@ public class WorkerProfileViewController: DisposableViewController {
         
         setApearance()
         setAutoLayout()
-        setObservable()
     }
     
     public required init?(coder: NSCoder) {
@@ -360,23 +360,20 @@ public class WorkerProfileViewController: DisposableViewController {
         ])
     }
     
-    private func setObservable() {
+    public func bind(_ viewModel: any WorkerProfileViewModelable) {
+        
+        self.viewModel = viewModel
         
         profileEditButton
             .eventPublisher
             .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] _ in
+            .subscribe(onNext: { [weak self, viewModel] _ in
                 let editVC = EditWorkerProfileViewController()
+                editVC.bind(viewModel: viewModel as! WorkerProfileEditViewModelable)
                 editVC.modalPresentationStyle = .fullScreen
-                self?.present(editVC, animated: true)
+                self?.navigationController?.pushViewController(editVC, animated: true)
             })
             .disposed(by: disposeBag)
-    }
-    
-    
-    public func bind(_ viewModel: any WorkerProfileViewModelable) {
-        
-        self.viewModel = viewModel
         
         // Input
         self.rx

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/profile/WorkerMyProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/profile/WorkerMyProfileViewModel.swift
@@ -1,0 +1,162 @@
+//
+//  WorkerProfileViewModel.swift
+//  WorkerFeature
+//
+//  Created by choijunios on 7/22/24.
+//
+
+import UIKit
+import PresentationCore
+import RxSwift
+import RxCocoa
+import DSKit
+import Entity
+
+public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
+    
+    // Input(Editing)
+    var requestUpload: PublishRelay<Void> = .init()
+    var editingImage: PublishRelay<UIImage> = .init()
+    var editingIsJobFinding: PublishRelay<Bool> = .init()
+    var editingExpYear: PublishRelay<Int> = .init()
+    var editingAddress: PublishRelay<AddressInformation> = .init()
+    var editingIntroduce: PublishRelay<String> = .init()
+    var editingSpecialty: PublishRelay<String> = .init()
+    
+    // Input(Rendering)
+    public var viewWillAppear: PublishRelay<Void> = .init()
+    
+    // Output
+    var uploadSuccess: Driver<Void>?
+    public var alert: Driver<Entity.DefaultAlertContentVO>?
+    
+    public var profileRenderObject: Driver<WorkerProfileRenderObject>?
+    private let rederingState: BehaviorRelay<WorkerProfileRenderObject> = .init(value: .createRO(isMyProfile: true, vo: .mock))
+    
+    // Editing & State
+    var willSubmitImage: UIImage?
+    var editingState: WorkerProfileStateObject = .default
+    var currentState: WorkerProfileStateObject = .default
+    
+    let disposbag: DisposeBag = .init()
+    
+    public init() {
+        
+        // Input(Rendering)
+        let fetchedProfileVOResult = viewWillAppear
+            .flatMap { [unowned self] _ in
+                
+                fetchProfileVO()
+            }
+            .share()
+        
+        let fetchedProfileVOSuccess = fetchedProfileVOResult
+            .compactMap { $0.value }
+            .map { [weak self] vo in
+                
+                if let self {
+                    currentState.experienceYear = vo.expYear
+                    currentState.introduce = vo.introductionText
+                    currentState.isJobFinding = vo.isLookingForJob
+                    currentState.lotNumberAddress = vo.address.jibunAddress
+                    currentState.roadNameAddress = vo.address.roadAddress
+                    currentState.speciality = vo.specialty
+                }
+                
+                return vo
+            }
+            
+        
+        fetchedProfileVOSuccess
+            .asObservable()
+            .map({ vo in
+                WorkerProfileRenderObject.createRO(isMyProfile: true, vo: vo)
+            })
+            .bind(to: rederingState)
+            .disposed(by: disposbag)
+        
+        // Edit Input
+        editingImage
+            .subscribe { [weak self] image in
+                self?.willSubmitImage = image
+            }
+            .disposed(by: disposbag)
+        
+        editingIsJobFinding
+            .subscribe { [weak self] isJobFinding in
+                self?.editingState.isJobFinding = isJobFinding
+            }
+            .disposed(by: disposbag)
+        
+        editingExpYear
+            .subscribe { [weak self] exp in
+                self?.editingState.experienceYear = exp
+            }
+            .disposed(by: disposbag)
+        
+        editingAddress
+            .subscribe(onNext: { [weak self] address in
+                self?.editingState.roadNameAddress = address.roadAddress
+                self?.editingState.lotNumberAddress = address.jibunAddress
+            })
+            .disposed(by: disposbag)
+        
+        editingIntroduce
+            .subscribe { [weak self] introduce in
+                self?.editingState.introduce = introduce
+            }
+            .disposed(by: disposbag)
+        
+        editingSpecialty
+            .subscribe { [weak self] special in
+                self?.editingState.speciality = special
+            }
+            .disposed(by: disposbag)
+        
+        let editingRequestResult = requestUpload
+            .flatMap { [unowned self] _ in
+                requestUpload(editObject: editingState)
+            }
+            .share()
+        
+        uploadSuccess = editingRequestResult
+            .compactMap { $0.value }
+            .asDriver(onErrorRecover: { _ in fatalError() })
+        
+        alert = editingRequestResult
+            .compactMap { $0.error }
+            .map { error in
+                DefaultAlertContentVO(
+                    title: "공고 수정 오류",
+                    message: error.message
+                )
+            }
+            .asDriver(onErrorJustReturn: .default)
+        
+        profileRenderObject = rederingState.asDriver(onErrorRecover: { _ in fatalError() })
+    }
+    
+    private func fetchProfileVO() -> Single<Result<WorkerProfileVO, Error>> {
+        return .just(.success(.mock))
+    }
+    
+    public func requestUpload(editObject: WorkerProfileStateObject) -> Single<Result<Void, UserInfoError>> {
+        
+        var submitObject: WorkerProfileStateObject = .init()
+        
+        submitObject.experienceYear = (currentState.experienceYear != editObject.experienceYear) ? editObject.experienceYear : nil
+        
+        submitObject.introduce = (currentState.introduce != editObject.introduce) ? editObject.introduce : nil
+        
+        submitObject.isJobFinding = (currentState.isJobFinding != editObject.isJobFinding) ? editObject.isJobFinding : nil
+        
+        submitObject.lotNumberAddress = (currentState.lotNumberAddress != editObject.lotNumberAddress) ? editObject.lotNumberAddress : nil
+        
+        submitObject.roadNameAddress = (currentState.roadNameAddress != editObject.roadNameAddress) ? editObject.roadNameAddress : nil
+        
+        submitObject.speciality = (currentState.speciality != editObject.speciality) ? editObject.speciality : nil
+        
+        return .just(.success(()))
+    }
+}
+

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/profile/WorkerProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/profile/WorkerProfileViewModel.swift
@@ -12,70 +12,151 @@ import RxCocoa
 import DSKit
 import Entity
 
-
-public struct WorkerProfileRenderObject {
+public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
     
-    let navigationTitle: String
-    let showEditButton: Bool
-    let stateText: String
-    let nameText: String
-    let ageText: String
-    let genderText: String
-    let expText: String
-    let address: String
-    let oneLineIntroduce: String
-    let specialty: String
-    let imageUrl: URL?
+    // Input(Editing)
+    var requestUpload: PublishRelay<Void> = .init()
+    var editingImage: PublishRelay<UIImage> = .init()
+    var editingIsJobFinding: PublishRelay<Bool> = .init()
+    var editingExpYear: PublishRelay<Int> = .init()
+    var editingAddress: PublishRelay<AddressInformation> = .init()
+    var editingIntroduce: PublishRelay<String> = .init()
+    var editingSpecialty: PublishRelay<String> = .init()
     
-    static func createRO(isMyProfile: Bool, vo: WorkerProfileVO) -> WorkerProfileRenderObject {
-        
-        .init(
-            navigationTitle: isMyProfile ? "내 프로필" : "요양보호사 프로필",
-            showEditButton: isMyProfile,
-            stateText: vo.isLookingForJob ? "구인중" : "휴식중",
-            nameText: vo.nameText,
-            ageText: "\(vo.age)세",
-            genderText: vo.gender.twoLetterKoreanWord,
-            expText: vo.expYear == nil ? "신입" : "\(vo.expYear!)년차",
-            address: vo.addressText,
-            oneLineIntroduce: vo.introductionText,
-            specialty: vo.specialty,
-            imageUrl: URL(string: vo.profileImageURL ?? "")
-        )
-    }
-}
-
-
-public class WorkerMyProfileViewModel: WorkerProfileViewModelable {
-    
-    // Input
+    // Input(Rendering)
     public var viewWillAppear: PublishRelay<Void> = .init()
     
     // Output
+    var uploadSuccess: Driver<Void>?
+    public var alert: Driver<Entity.DefaultAlertContentVO>?
+    
     public var profileRenderObject: Driver<WorkerProfileRenderObject>?
+    private let rederingState: BehaviorRelay<WorkerProfileRenderObject> = .init(value: .createRO(isMyProfile: true, vo: .mock))
+    
+    // Editing & State
+    var willSubmitImage: UIImage?
+    var editingState: WorkerProfileStateObject = .default
+    var currentState: WorkerProfileStateObject = .default
+    
+    let disposbag: DisposeBag = .init()
     
     public init() {
         
-        // Input
+        // Input(Rendering)
         let fetchedProfileVOResult = viewWillAppear
             .flatMap { [unowned self] _ in
+                
                 fetchProfileVO()
             }
             .share()
         
         let fetchedProfileVOSuccess = fetchedProfileVOResult
             .compactMap { $0.value }
+            .map { [weak self] vo in
+                
+                if let self {
+                    currentState.experienceYear = vo.expYear
+                    currentState.introduce = vo.introductionText
+                    currentState.isJobFinding = vo.isLookingForJob
+                    currentState.lotNumberAddress = vo.address.jibunAddress
+                    currentState.roadNameAddress = vo.address.roadAddress
+                    currentState.speciality = vo.specialty
+                }
+                
+                return vo
+            }
+            
         
-        profileRenderObject = fetchedProfileVOSuccess
+        fetchedProfileVOSuccess
+            .asObservable()
             .map({ vo in
-                WorkerProfileRenderObject.createRO(isMyProfile: false, vo: vo)
+                WorkerProfileRenderObject.createRO(isMyProfile: true, vo: vo)
             })
+            .bind(to: rederingState)
+            .disposed(by: disposbag)
+        
+        // Edit Input
+        editingImage
+            .subscribe { [weak self] image in
+                self?.willSubmitImage = image
+            }
+            .disposed(by: disposbag)
+        
+        editingIsJobFinding
+            .subscribe { [weak self] isJobFinding in
+                self?.editingState.isJobFinding = isJobFinding
+            }
+            .disposed(by: disposbag)
+        
+        editingExpYear
+            .subscribe { [weak self] exp in
+                self?.editingState.experienceYear = exp
+            }
+            .disposed(by: disposbag)
+        
+        editingAddress
+            .subscribe(onNext: { [weak self] address in
+                self?.editingState.roadNameAddress = address.roadAddress
+                self?.editingState.lotNumberAddress = address.jibunAddress
+            })
+            .disposed(by: disposbag)
+        
+        editingIntroduce
+            .subscribe { [weak self] introduce in
+                self?.editingState.introduce = introduce
+            }
+            .disposed(by: disposbag)
+        
+        editingSpecialty
+            .subscribe { [weak self] special in
+                self?.editingState.speciality = special
+            }
+            .disposed(by: disposbag)
+        
+        let editingRequestResult = requestUpload
+            .flatMap { [unowned self] _ in
+                requestUpload(editObject: editingState)
+            }
+            .share()
+        
+        uploadSuccess = editingRequestResult
+            .compactMap { $0.value }
             .asDriver(onErrorRecover: { _ in fatalError() })
         
+        alert = editingRequestResult
+            .compactMap { $0.error }
+            .map { error in
+                DefaultAlertContentVO(
+                    title: "공고 수정 오류",
+                    message: error.message
+                )
+            }
+            .asDriver(onErrorJustReturn: .default)
+        
+        profileRenderObject = rederingState.asDriver(onErrorRecover: { _ in fatalError() })
     }
     
     private func fetchProfileVO() -> Single<Result<WorkerProfileVO, Error>> {
         return .just(.success(.mock))
+    }
+    
+    public func requestUpload(editObject: WorkerProfileStateObject) -> Single<Result<Void, UserInfoError>> {
+        
+        var submitObject: WorkerProfileStateObject = .init()
+        
+        submitObject.experienceYear = (currentState.experienceYear != editObject.experienceYear) ? editObject.experienceYear : nil
+        
+        submitObject.introduce = (currentState.introduce != editObject.introduce) ? editObject.introduce : nil
+        
+        submitObject.isJobFinding = (currentState.isJobFinding != editObject.isJobFinding) ? editObject.isJobFinding : nil
+        
+        submitObject.lotNumberAddress = (currentState.lotNumberAddress != editObject.lotNumberAddress) ? editObject.lotNumberAddress : nil
+        
+        submitObject.roadNameAddress = (currentState.roadNameAddress != editObject.roadNameAddress) ? editObject.roadNameAddress : nil
+        
+        submitObject.speciality = (currentState.speciality != editObject.speciality) ? editObject.speciality : nil
+        
+        return .just(.success(()))
     }
 }
 

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/profile/WorkerProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/profile/WorkerProfileViewModel.swift
@@ -2,7 +2,7 @@
 //  WorkerProfileViewModel.swift
 //  WorkerFeature
 //
-//  Created by choijunios on 7/22/24.
+//  Created by choijunios on 8/10/24.
 //
 
 import UIKit
@@ -12,16 +12,10 @@ import RxCocoa
 import DSKit
 import Entity
 
-public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
+public class WorkerProfileViewModel: WorkerProfileViewModelable {
     
-    // Input(Editing)
-    var requestUpload: PublishRelay<Void> = .init()
-    var editingImage: PublishRelay<UIImage> = .init()
-    var editingIsJobFinding: PublishRelay<Bool> = .init()
-    var editingExpYear: PublishRelay<Int> = .init()
-    var editingAddress: PublishRelay<AddressInformation> = .init()
-    var editingIntroduce: PublishRelay<String> = .init()
-    var editingSpecialty: PublishRelay<String> = .init()
+    // Init
+    let workerId: String
     
     // Input(Rendering)
     public var viewWillAppear: PublishRelay<Void> = .init()
@@ -40,7 +34,9 @@ public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
     
     let disposbag: DisposeBag = .init()
     
-    public init() {
+    public init(workerId: String) {
+        
+        self.workerId = workerId
         
         // Input(Rendering)
         let fetchedProfileVOResult = viewWillAppear
@@ -65,73 +61,14 @@ public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
                 
                 return vo
             }
-            
         
         fetchedProfileVOSuccess
             .asObservable()
             .map({ vo in
-                WorkerProfileRenderObject.createRO(isMyProfile: true, vo: vo)
+                WorkerProfileRenderObject.createRO(isMyProfile: false, vo: vo)
             })
             .bind(to: rederingState)
             .disposed(by: disposbag)
-        
-        // Edit Input
-        editingImage
-            .subscribe { [weak self] image in
-                self?.willSubmitImage = image
-            }
-            .disposed(by: disposbag)
-        
-        editingIsJobFinding
-            .subscribe { [weak self] isJobFinding in
-                self?.editingState.isJobFinding = isJobFinding
-            }
-            .disposed(by: disposbag)
-        
-        editingExpYear
-            .subscribe { [weak self] exp in
-                self?.editingState.experienceYear = exp
-            }
-            .disposed(by: disposbag)
-        
-        editingAddress
-            .subscribe(onNext: { [weak self] address in
-                self?.editingState.roadNameAddress = address.roadAddress
-                self?.editingState.lotNumberAddress = address.jibunAddress
-            })
-            .disposed(by: disposbag)
-        
-        editingIntroduce
-            .subscribe { [weak self] introduce in
-                self?.editingState.introduce = introduce
-            }
-            .disposed(by: disposbag)
-        
-        editingSpecialty
-            .subscribe { [weak self] special in
-                self?.editingState.speciality = special
-            }
-            .disposed(by: disposbag)
-        
-        let editingRequestResult = requestUpload
-            .flatMap { [unowned self] _ in
-                requestUpload(editObject: editingState)
-            }
-            .share()
-        
-        uploadSuccess = editingRequestResult
-            .compactMap { $0.value }
-            .asDriver(onErrorRecover: { _ in fatalError() })
-        
-        alert = editingRequestResult
-            .compactMap { $0.error }
-            .map { error in
-                DefaultAlertContentVO(
-                    title: "공고 수정 오류",
-                    message: error.message
-                )
-            }
-            .asDriver(onErrorJustReturn: .default)
         
         profileRenderObject = rederingState.asDriver(onErrorRecover: { _ in fatalError() })
     }
@@ -141,20 +78,6 @@ public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
     }
     
     public func requestUpload(editObject: WorkerProfileStateObject) -> Single<Result<Void, UserInfoError>> {
-        
-        var submitObject: WorkerProfileStateObject = .init()
-        
-        submitObject.experienceYear = (currentState.experienceYear != editObject.experienceYear) ? editObject.experienceYear : nil
-        
-        submitObject.introduce = (currentState.introduce != editObject.introduce) ? editObject.introduce : nil
-        
-        submitObject.isJobFinding = (currentState.isJobFinding != editObject.isJobFinding) ? editObject.isJobFinding : nil
-        
-        submitObject.lotNumberAddress = (currentState.lotNumberAddress != editObject.lotNumberAddress) ? editObject.lotNumberAddress : nil
-        
-        submitObject.roadNameAddress = (currentState.roadNameAddress != editObject.roadNameAddress) ? editObject.roadNameAddress : nil
-        
-        submitObject.speciality = (currentState.speciality != editObject.speciality) ? editObject.speciality : nil
         
         return .just(.success(()))
     }

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/profile/WorkerProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/profile/WorkerProfileViewModel.swift
@@ -11,8 +11,11 @@ import RxSwift
 import RxCocoa
 import DSKit
 import Entity
+import UseCaseInterface
 
 public class WorkerProfileViewModel: WorkerProfileViewModelable {
+    
+    let workerProfileUseCase: WorkerProfileUseCase
     
     // Init
     let workerId: String
@@ -34,8 +37,9 @@ public class WorkerProfileViewModel: WorkerProfileViewModelable {
     
     let disposbag: DisposeBag = .init()
     
-    public init(workerId: String) {
+    public init(workerProfileUseCase: WorkerProfileUseCase, workerId: String) {
         
+        self.workerProfileUseCase = workerProfileUseCase
         self.workerId = workerId
         
         // Input(Rendering)
@@ -73,13 +77,9 @@ public class WorkerProfileViewModel: WorkerProfileViewModelable {
         profileRenderObject = rederingState.asDriver(onErrorRecover: { _ in fatalError() })
     }
     
-    private func fetchProfileVO() -> Single<Result<WorkerProfileVO, Error>> {
-        return .just(.success(.mock))
-    }
-    
-    public func requestUpload(editObject: WorkerProfileStateObject) -> Single<Result<Void, UserInfoError>> {
-        
-        return .just(.success(()))
+    private func fetchProfileVO() -> Single<Result<WorkerProfileVO, UserInfoError>> {
+        workerProfileUseCase
+            .getProfile(mode: .otherProfile(id: self.workerId))
     }
 }
 

--- a/project/Tuist/Package.swift
+++ b/project/Tuist/Package.swift
@@ -40,5 +40,7 @@ let package = Package(
         .package(url: "https://github.com/WenchaoD/FSCalendar.git", from: "2.8.4"),
         // Naver map
         .package(url: "https://github.com/J0onYEong/NaverMapSDKForSPM.git", from: "1.0.0"),
+        // KingFisher
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.12.0")
     ]
 )


### PR DESCRIPTION
## 변경된점

- 요양보호사 프로필 확인 및 수청 최신 UI가 적용되었습니다.
- 프로필 UI를 재사용하기 위해(자신의 프로필 확인 / 타인의 프로필 확인) ViewModel을 추상화하였습니다.

### 수정과 정보의 표출이 모두 일어나는 뷰

해당 방식은 아래와 그림과 같이 설계하고 구현되었습니다. UI에 표시할 값을 전달하는 옵저버블과 UI로 부터 값을 전달받는 옵저버블을 분리하였습니다.
그리고 ViewModel내에 프로퍼티로 정의된 상태를 업데이트하고 기존상태와 변경된 상태를 비교합니다.
최종적으로 API를 호출할 때는 변경된 값만 제출할 수 있는 구조가 완성됩니다.
수정을 요청한 이후 변경된 값을 불러오는 API를 요청하여 기존의 StateObject(그림내 최신값)을 업데이트 합니다. 
따라서 StateFul 상태로 발생할 수 있는 사이드 이팩트를 막을 수 있었습니다.

![image](https://github.com/user-attachments/assets/e2ece81a-187d-40ac-8d32-c304b7ee806c)

그림에 보면 RenderObject라는 타입이 VO로 부터 파생되도록 설정했습니다.
보여지는 정보가 많은 화면이라 화면맞게 변형하는 것을 데이터 레이어에서 하기보단 Presentation에서 하는게 적합하다고 판단하였습니다.
따라서 Presentation레이어 모듈에 RenderObject를 선언하였고 앞서언급한 UI맞춤형 데아터 변환을 VO -> RO 과정에서 수행하도록 하였습니다.

아래코는 ViewModel코드및 RenderObject코드입니다.
<img width="645" alt="스크린샷 2024-08-10 오후 10 39 22" src="https://github.com/user-attachments/assets/8acac01b-0a25-4613-ba60-33650f876f55">

### 결과물 영상

사진업로드 API가 백에드단에 문제가 있어 오류발생한 점 양해바랍니다.

![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-08-10 at 22 07 51](https://github.com/user-attachments/assets/348cd0dc-80f5-4cbf-b854-47a8a11d3d32)
