### PR TITLE
[IDLE-000] 메인화면 위치표시및 공고 카드 변경된 디자인 적용

### DIFF
--- a/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/WorkerRecruitmentBoardCoordinator.swift
+++ b/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/WorkerRecruitmentBoardCoordinator.swift
@@ -44,7 +44,8 @@ class WorkerRecruitmentBoardCoordinator: WorkerRecruitmentBoardCoordinatable {
         let vc = WorkerRecruitmentPostBoardVC()
         let vm = WorkerRecruitmentPostBoardVM(
             coordinator: self,
-            recruitmentPostUseCase: injector.resolve(RecruitmentPostUseCase.self)
+            recruitmentPostUseCase: injector.resolve(RecruitmentPostUseCase.self),
+            workerProfileUseCase: injector.resolve(WorkerProfileUseCase.self)
         )
         vc.bind(viewModel: vm)
         viewControllerRef = vc

--- a/project/Projects/Domain/ConcreteUseCase/UserInfo/DefaultCenterProfileUseCase.swift
+++ b/project/Projects/Domain/ConcreteUseCase/UserInfo/DefaultCenterProfileUseCase.swift
@@ -22,7 +22,13 @@ public class DefaultCenterProfileUseCase: CenterProfileUseCase {
     }
     
     public func getProfile(mode: ProfileMode) -> Single<Result<CenterProfileVO, DomainError>> {
-        convert(task: userProfileRepository.getCenterProfile(mode: mode))
+        
+        if let cachedProfile = userInfoLocalRepository.getCurrentCenterData() {
+            // 캐쉬된 데이터 전송
+            return .just(.success(cachedProfile))
+        }
+        
+        return convert(task: userProfileRepository.getCenterProfile(mode: mode))
     }
     
     public func updateProfile(phoneNumber: String?, introduction: String?, imageInfo: ImageUploadInfo?) -> Single<Result<Void, DomainError>> {

--- a/project/Projects/Domain/ConcreteUseCase/UserInfo/DefaultWorkerProfileUseCase.swift
+++ b/project/Projects/Domain/ConcreteUseCase/UserInfo/DefaultWorkerProfileUseCase.swift
@@ -22,7 +22,13 @@ public class DefaultWorkerProfileUseCase: WorkerProfileUseCase {
     }
     
     public func getProfile(mode: ProfileMode) -> Single<Result<WorkerProfileVO, DomainError>> {
-        convert(task: userProfileRepository.getWorkerProfile(mode: mode))
+        
+        if let cachedProfile = userInfoLocalRepository.getCurrentWorkerData() {
+            // Cache된 정보가 있는 경우 해당 값을 전달
+            return .just(.success(cachedProfile))
+        }
+        
+        return convert(task: userProfileRepository.getWorkerProfile(mode: mode))
     }
     
     public func updateProfile(stateObject: WorkerProfileStateObject, imageInfo: ImageUploadInfo?) -> Single<Result<Void, DomainError>> {

--- a/project/Projects/Domain/Entity/State/Profile/ProfileMode.swift
+++ b/project/Projects/Domain/Entity/State/Profile/ProfileMode.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum ProfileMode {
+public enum ProfileMode: Equatable {
     case myProfile
     case otherProfile(id: String)
 }

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Card/Post/Worker/WorkerEmployCard.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Card/Post/Worker/WorkerEmployCard.swift
@@ -164,11 +164,6 @@ public class WorkerEmployCard: UIView {
         let label = IdleLabel(typography: .Subtitle2)
         return label
     }()
-    let distanceFromWorkPlaceLabel: IdleLabel = {
-        let label = IdleLabel(typography: .Body3)
-        label.attrTextColor = DSKitAsset.Colors.gray500.color
-        return label
-    }()
     
     let serviceTargetInfoLabel: IdleLabel = {
         let label = IdleLabel(typography: .Body2)
@@ -228,16 +223,6 @@ public class WorkerEmployCard: UIView {
             starButton.widthAnchor.constraint(equalToConstant: 24),
             starButton.heightAnchor.constraint(equalTo: starButton.widthAnchor),
         ])
-        
-        // MARK: Title & takenTimesForWalk
-        let titleStack = HStack(
-            [
-                titleLabel,
-                distanceFromWorkPlaceLabel
-            ],
-            spacing: 8,
-            alignment: .bottom
-        )
         
         let divider = UIView()
         divider.backgroundColor = DSKitAsset.Colors.gray300.color
@@ -310,7 +295,9 @@ public class WorkerEmployCard: UIView {
             tagStarStack,
             Spacer(height: 8),
             VStack(
-                [titleStack,serviceTargetInfoLabel],
+                [
+                    titleLabel, serviceTargetInfoLabel
+                ],
                 spacing: 2,
                 alignment: .leading
             ),
@@ -345,7 +332,6 @@ public class WorkerEmployCard: UIView {
     
     public func setToPostAppearance() {
         titleLabel.typography = .Subtitle1
-        distanceFromWorkPlaceLabel.isHidden = true
         serviceTargetInfoLabel.typography = .Body3
         workDaysLabel.typography = .Body2
         workTimeLabel.typography = .Body2

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Card/Post/Worker/WorkerEmployCard.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Card/Post/Worker/WorkerEmployCard.swift
@@ -13,10 +13,8 @@ import Entity
 public class WorkerNativeEmployCardRO {
     
     let showBiginnerTag: Bool
-    let showDayLeftTag: Bool
-    let dayLeftTagText: String?
     let titleText: String
-    let distanceFromWorkPlaceText: String
+    let timeDurationForWalkingText: String
     let targetInfoText: String
     let workDaysText: String
     let workTimeText: String
@@ -25,10 +23,8 @@ public class WorkerNativeEmployCardRO {
     
     init(
         showBiginnerTag: Bool,
-        showDayLeftTag: Bool,
-        dayLeftTagText: String?,
         titleText: String,
-        distanceFromWorkPlaceText: String,
+        timeDurationForWalkingText: String,
         targetInfoText: String,
         workDaysText: String,
         workTimeText: String,
@@ -36,10 +32,8 @@ public class WorkerNativeEmployCardRO {
         isFavorite: Bool
     ) {
         self.showBiginnerTag = showBiginnerTag
-        self.showDayLeftTag = showDayLeftTag
-        self.dayLeftTagText = dayLeftTagText
         self.titleText = titleText
-        self.distanceFromWorkPlaceText = distanceFromWorkPlaceText
+        self.timeDurationForWalkingText = timeDurationForWalkingText
         self.targetInfoText = targetInfoText
         self.workDaysText = workDaysText
         self.workTimeText = workTimeText
@@ -49,13 +43,13 @@ public class WorkerNativeEmployCardRO {
     
     public static func create(vo: WorkerNativeEmployCardVO) -> WorkerNativeEmployCardRO {
 
-        var dayLeftTagText: String? = nil
-        var showDayLeftTag: Bool = false
-        
-        if (0...14).contains(vo.dayLeft) {
-            showDayLeftTag = true
-            dayLeftTagText = vo.dayLeft == 0 ? "D-Day" : "D-\(vo.dayLeft)"
-        }
+//        var dayLeftTagText: String? = nil
+//        var showDayLeftTag: Bool = false
+//        
+//        if (0...14).contains(vo.dayLeft) {
+//            showDayLeftTag = true
+//            dayLeftTagText = vo.dayLeft == 0 ? "D-Day" : "D-\(vo.dayLeft)"
+//        }
        
         let targetInfoText = "\(vo.careGrade.textForCellBtn)등급 \(vo.targetAge)세 \(vo.targetGender.twoLetterKoreanWord)"
         
@@ -83,19 +77,12 @@ public class WorkerNativeEmployCardRO {
         let addressTitle = splittedAddress.joined(separator: " ")
         
         // distance는 미터단위입니다.
-        var distanceText: String = "\(vo.distanceFromWorkPlace)m"
-
-        if vo.distanceFromWorkPlace >= 1000 {
-            let kilometers = Double(vo.distanceFromWorkPlace)/1000.0
-            distanceText = String(format: "%.1fkm", kilometers)
-        }
+        let durationText = Self.timeForDistance(meter: vo.distanceFromWorkPlace)
         
         return .init(
             showBiginnerTag: vo.isBeginnerPossible,
-            showDayLeftTag: showDayLeftTag,
-            dayLeftTagText: dayLeftTagText,
             titleText: addressTitle,
-            distanceFromWorkPlaceText: distanceText,
+            timeDurationForWalkingText: durationText,
             targetInfoText: targetInfoText,
             workDaysText: workDaysText,
             workTimeText: workTimeText,
@@ -106,16 +93,38 @@ public class WorkerNativeEmployCardRO {
     
     public static let `mock`: WorkerNativeEmployCardRO = .init(
         showBiginnerTag: true,
-        showDayLeftTag: true,
-        dayLeftTagText: "D-14",
         titleText: "사울시 강남동",
-        distanceFromWorkPlaceText: "1.1km",
+        timeDurationForWalkingText: "도보 15분 ~ 20분",
         targetInfoText: "1등급 54세 여성",
         workDaysText: "",
         workTimeText: "월, 화, 수",
         payText: "시급 5000원",
         isFavorite: true
     )
+    
+    static func timeForDistance(meter: Int) -> String {
+        switch meter {
+        case 0..<200:
+            return "도보 5분 이내"
+        case 200..<400:
+            return "도보 5 ~ 10분"
+        case 400..<700:
+            return "도보 10 ~ 15분"
+        case 700..<1000:
+            return "도보 15 ~ 20분"
+        case 1000..<1250:
+            return "도보 20 ~ 25분"
+        case 1250..<1500:
+            return "도보 25 ~ 30분"
+        case 1500..<1750:
+            return "도보 30 ~ 35분"
+        case 1750..<2000:
+            return "도보 35 ~ 40분"
+        default:
+            return "도보 40분 ~"
+        }
+    }
+
 }
 
 
@@ -140,12 +149,12 @@ public class WorkerEmployCard: UIView {
         )
         return tag
     }()
-    let dayLeftTag: TagLabel = {
+    let timeDurationForWorkingTag: TagLabel = {
         let tag = TagLabel(
             text: "",
             typography: .caption,
             textColor: DSKitAsset.Colors.gray300.color,
-            backgroundColor: DSKitAsset.Colors.gray100.color
+            backgroundColor: DSKitAsset.Colors.gray050.color
         )
         return tag
     }()
@@ -199,7 +208,7 @@ public class WorkerEmployCard: UIView {
         let tagStack = HStack(
             [
                 beginnerTag,
-                dayLeftTag
+                timeDurationForWorkingTag
             ],
             spacing: 4
         )
@@ -345,10 +354,8 @@ public class WorkerEmployCard: UIView {
     
     public func bind(ro: WorkerNativeEmployCardRO) {
         beginnerTag.isHidden = !ro.showBiginnerTag
-        dayLeftTag.isHidden = !ro.showDayLeftTag
-        dayLeftTag.textString = ro.dayLeftTagText ?? ""
+        timeDurationForWorkingTag.textString = ro.timeDurationForWalkingText
         titleLabel.textString = ro.titleText
-        distanceFromWorkPlaceLabel.textString = ro.distanceFromWorkPlaceText
         serviceTargetInfoLabel.textString = ro.targetInfoText
         workDaysLabel.textString = ro.workDaysText
         workTimeLabel.textString = ro.workTimeText

--- a/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/ViewModel/NativePostDetailForWorkerVM.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/ViewModel/NativePostDetailForWorkerVM.swift
@@ -269,7 +269,8 @@ public class NativePostDetailForWorkerVM: BaseViewModel ,NativePostDetailForWork
                 }
                 .asObservable()
                 .subscribe(onNext: { [weak self] alertVO in
-                    self?.alert.onNext(alertVO)
+                    guard let self else { return }
+                    alert.onNext(alertVO)
                 })
                 
             	

--- a/project/Projects/Presentation/Feature/Base/Sources/View/ViewController/BottomSheet/IdleBottomSheetVC.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/View/ViewController/BottomSheet/IdleBottomSheetVC.swift
@@ -109,6 +109,13 @@ open class IdleBottomSheetVC: BaseViewController {
 /// 뷰 디스플레이 관련
 extension IdleBottomSheetVC {
     
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // 애니메이션 시작전에 해당뷰를 화면 밖으로 이동한다.
+        sheetView.transform = .init(translationX: 0, y: 1000)
+    }
+    
     /// viewDidAppear서브 뷰들의 레이아웃이 결정된 이후 시점(화면상에 나타난 시점)으로, frame, bounds에 근거있는 값들이 할당된 이후이다.
     public override func viewDidAppear(_ animated: Bool) {
         

--- a/project/Projects/Presentation/Feature/Center/Sources/View/Profile/CenterProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Center/Sources/View/Profile/CenterProfileViewController.swift
@@ -15,8 +15,9 @@ import BaseFeature
 
 public class CenterProfileViewController: BaseViewController {
     
-    let navigationBar: NavigationBarType1 = {
-        let bar = NavigationBarType1(navigationTitle: "내 센터 정보")
+    // View
+    lazy var navigationBar: IdleNavigationBar = {
+        let bar = IdleNavigationBar(innerViews: [profileEditButton, editingCompleteButton])
         return bar
     }()
     
@@ -27,7 +28,15 @@ public class CenterProfileViewController: BaseViewController {
         return btn
     }()
     
-    // View
+    let profileEditButton: TextButtonType2 = {
+        let button = TextButtonType2(labelText: "수정하기")
+        
+        button.label.typography = .Body3
+        button.label.attrTextColor = DSKitAsset.Colors.gray300.color
+        button.layoutMargins = .init(top: 5.5, left:12, bottom: 5.5, right: 12)
+        button.layer.cornerRadius = 16
+        return button
+    }()
     
     /// Center name label
     let centerNameLabel: IdleLabel = {
@@ -48,16 +57,7 @@ public class CenterProfileViewController: BaseViewController {
         label.textString = "센터 상세 정보"
         return label
     }()
-    let profileEditButton: TextButtonType2 = {
-        let button = TextButtonType2(labelText: "수정하기")
-        
-        button.label.typography = .Body3
-        button.label.attrTextColor = DSKitAsset.Colors.gray300.color
-        button.layoutMargins = .init(top: 5.5, left:12, bottom: 5.5, right: 12)
-        button.layer.cornerRadius = 16
-        return button
-    }()
-    
+
     /// ☑️ "전화번호" 라벨 ☑️
     let centerPhoneNumeberTitleLabel: IdleLabel = {
         let label = IdleLabel(typography: .Subtitle4)
@@ -134,26 +134,6 @@ public class CenterProfileViewController: BaseViewController {
     
     func setAutoLayout() {
         
-        // 상단 네비게이션바 세팅
-        let navigationStack = HStack([
-            navigationBar,
-            editingCompleteButton,
-        ])
-        navigationStack.distribution = .equalSpacing
-        navigationStack.backgroundColor = .white
-        
-        let navigationStackBackground = UIView()
-        navigationStackBackground.addSubview(navigationStack)
-        navigationStack.translatesAutoresizingMaskIntoConstraints = false
-        navigationStackBackground.backgroundColor = .white
-        navigationStackBackground.layoutMargins = .init(top: 0, left: 12, bottom: 0, right: 28)
-        NSLayoutConstraint.activate([
-            navigationStack.topAnchor.constraint(equalTo: navigationStackBackground.layoutMarginsGuide.topAnchor),
-            navigationStack.leadingAnchor.constraint(equalTo: navigationStackBackground.layoutMarginsGuide.leadingAnchor),
-            navigationStack.trailingAnchor.constraint(equalTo: navigationStackBackground.layoutMarginsGuide.trailingAnchor),
-            navigationStack.bottomAnchor.constraint(equalTo: navigationStackBackground.layoutMarginsGuide.bottomAnchor),
-        ])
-        
         let locationIcon = UIImageView.locationMark
         locationIcon.tintColor = DSColor.gray700.color
         
@@ -198,7 +178,6 @@ public class CenterProfileViewController: BaseViewController {
             divider,
             
             centerDetailLabel,
-            profileEditButton,
             
             centerPhoneNumberStack,
             
@@ -212,23 +191,20 @@ public class CenterProfileViewController: BaseViewController {
         }
         
         [
-            navigationStackBackground,
+            navigationBar,
             scrollView
         ].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview($0)
         }
-        // view 서브뷰 zindex설정
-        navigationStackBackground.layer.zPosition = 1
-        scrollView.layer.zPosition = 0
         
         // 전체 뷰
         NSLayoutConstraint.activate([
-            navigationStackBackground.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            navigationStackBackground.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            navigationStackBackground.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            navigationBar.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            navigationBar.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             
-            scrollView.topAnchor.constraint(equalTo: navigationStackBackground.bottomAnchor),
+            scrollView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor),
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
@@ -262,9 +238,6 @@ public class CenterProfileViewController: BaseViewController {
             
             centerDetailLabel.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 24),
             centerDetailLabel.leadingAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.leadingAnchor),
-            
-            profileEditButton.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 24),
-            profileEditButton.trailingAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.trailingAnchor),
             
             centerPhoneNumberStack.topAnchor.constraint(equalTo: centerDetailLabel.bottomAnchor, constant: 20),
             centerPhoneNumberStack.leadingAnchor.constraint(equalTo: scrollView.layoutMarginsGuide.leadingAnchor),
@@ -334,12 +307,15 @@ public class CenterProfileViewController: BaseViewController {
         }
         
         navigationBar
-            .eventPublisher
+            .backButton
+            .rx.tap
             .bind(to: input.exitButtonClicked)
             .disposed(by: disposeBag)
         
         // output
         guard let output = viewModel.output else { fatalError() }
+        
+        navigationBar.titleLabel.textString = output.navigationBarTitle
         
         output
             .centerName

--- a/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
@@ -40,6 +40,7 @@ public protocol CenterProfileInputable {
 }
 
 public protocol CenterProfileOutputable {
+    var navigationBarTitle: String { get }
     var centerName: Driver<String> { get }
     var centerLocation: Driver<String> { get }
     var centerPhoneNumber: Driver<String> { get }
@@ -269,7 +270,10 @@ public class CenterProfileViewModel: BaseViewModel, CenterProfileViewModelable {
             })
             .disposed(by: disposeBag)
         
+        let navigationBarTitle = (mode == .myProfile ? "내 센터 정보" : "센터 정보")
+        
         self.output = .init(
+            navigationBarTitle: navigationBarTitle,
             centerName: centerNameDriver,
             centerLocation: centerAddressDriver,
             centerPhoneNumber: centerPhoneNumberDriver,
@@ -306,6 +310,7 @@ public extension CenterProfileViewModel {
     
     class Output: CenterProfileOutputable {
         // 기본 데이터
+        public let navigationBarTitle: String
         public var centerName: Driver<String>
         public var centerLocation: Driver<String>
         public var centerPhoneNumber: Driver<String>
@@ -318,7 +323,17 @@ public extension CenterProfileViewModel {
         // 요구사항 X
         public var editingValidation: Driver<Void>
         
-        init(centerName: Driver<String>, centerLocation: Driver<String>, centerPhoneNumber: Driver<String>, centerIntroduction: Driver<String>, displayingImage: Driver<UIImage?>, isEditingMode: Driver<Bool>, editingValidation: Driver<Void>) {
+        init(
+            navigationBarTitle: String,
+            centerName: Driver<String>,
+            centerLocation: Driver<String>,
+            centerPhoneNumber: Driver<String>,
+            centerIntroduction: Driver<String>,
+            displayingImage: Driver<UIImage?>,
+            isEditingMode: Driver<Bool>,
+            editingValidation: Driver<Void>
+        ) {
+            self.navigationBarTitle = navigationBarTitle
             self.centerName = centerName
             self.centerLocation = centerLocation
             self.centerPhoneNumber = centerPhoneNumber

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/AppliedPostBoardVM.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/AppliedPostBoardVM.swift
@@ -149,7 +149,7 @@ public class AppliedPostBoardVM: BaseViewModel, WorkerPagablePostBoardVMable {
         
         Observable
             .merge(loadingEndObservables)
-            .delay(.milliseconds(500), scheduler: MainScheduler.instance)
+            .delay(.milliseconds(300), scheduler: MainScheduler.instance)
             .subscribe(self.dismissLoading)
             .disposed(by: disposeBag)
     }

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVM.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVM.swift
@@ -69,6 +69,7 @@ public class WorkerRecruitmentPostBoardVM: BaseViewModel, WorkerRecruitmentPostB
     // Init
     public weak var coordinator: WorkerRecruitmentBoardCoordinatable?
     public let recruitmentPostUseCase: RecruitmentPostUseCase
+    public let workerProfileUseCase: WorkerProfileUseCase
     
     // Paging
     /// 값이 nil이라면 요청을 보내지 않습니다.
@@ -81,11 +82,13 @@ public class WorkerRecruitmentPostBoardVM: BaseViewModel, WorkerRecruitmentPostB
     
     public init(
         coordinator: WorkerRecruitmentBoardCoordinatable,
-        recruitmentPostUseCase: RecruitmentPostUseCase
+        recruitmentPostUseCase: RecruitmentPostUseCase,
+        workerProfileUseCase: WorkerProfileUseCase
         )
     {
         self.coordinator = coordinator
         self.recruitmentPostUseCase = recruitmentPostUseCase
+        self.workerProfileUseCase = workerProfileUseCase
         
         super.init()
         
@@ -94,9 +97,10 @@ public class WorkerRecruitmentPostBoardVM: BaseViewModel, WorkerRecruitmentPostB
         
         // MARK: 상단 위치정보 불러오기
         workerLocationTitleText = requestWorkerLocation
-            .compactMap { [weak self] _ in
-                self?.fetchWorkerLocation()
+            .flatMap { [workerProfileUseCase] _ in
+                workerProfileUseCase.getProfile(mode: .myProfile)
             }
+            .map(<#T##transform: (Result<WorkerProfileVO, DomainError>) throws -> Result##(Result<WorkerProfileVO, DomainError>) throws -> Result#>)
             .asDriver(onErrorJustReturn: "위치정보확인불가")
         
         // MARK: 지원하기
@@ -283,7 +287,7 @@ public class WorkerRecruitmentPostBoardVM: BaseViewModel, WorkerRecruitmentPostB
     
     /// Test
     func fetchWorkerLocation() -> String {
-        "서울시 영등포구"
+        workerProfileUseCase.getProfile(mode: .myProfile)
     }
 }
 

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVM.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVM.swift
@@ -290,7 +290,7 @@ public class WorkerRecruitmentPostBoardVM: BaseViewModel, WorkerRecruitmentPostB
         
         Observable
             .merge(loadingEndObservables)
-            .delay(.milliseconds(500), scheduler: MainScheduler.instance)
+            .delay(.milliseconds(300), scheduler: MainScheduler.instance)
             .subscribe(self.dismissLoading)
             .disposed(by: dispostBag)
     }

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/StarredPostBoardVM.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/StarredPostBoardVM.swift
@@ -190,7 +190,7 @@ public class StarredPostBoardVM: BaseViewModel, WorkerAppliablePostBoardVMable {
         
         Observable
             .merge(loadingEndObservables)
-            .delay(.milliseconds(500), scheduler: MainScheduler.instance)
+            .delay(.milliseconds(300), scheduler: MainScheduler.instance)
             .subscribe(self.dismissLoading)
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 변경된점

- 메인화면 좌측 상단에 요양보호사 위치표시
- 공고 카드 상단에, 도보거리표시

### 메인화면 좌측 상단에 요양보호사 위치표시

앱을 시작하면 로컬에 저장된 정보(토큰, 유저타입)을 사용하여 유저 프로필을 요청합니다.
해당 요청이 발생하는 이유 두가지 입니다.
- 앱시작시 불러온 프로필 정보를 로컬에 캐싱해 두고 필요할 때마다 꺼내 쓰기
- 유저의 토큰을 앱시작시 강제로 리프래쉬 하게하고 만료시 바로 로그인 화면으로 이동시키기 위해서

Worker/Center의 ProfileUseCase에서 요청전 캐싱정보가 있는지 확인합니다.

![스크린샷 2024-09-05 오후 1 14 23](https://github.com/user-attachments/assets/e5fc0fa5-bfba-4b12-9ba4-169c1d9f4476)


<img width="353" alt="스크린샷 2024-09-05 오후 1 13 30" src="https://github.com/user-attachments/assets/ada1547d-f1c8-483b-ba2f-10aaa73a923c">

### 공고 카드에 도보거리 태그 표시
<img width="363" alt="스크린샷 2024-09-05 오후 1 11 16" src="https://github.com/user-attachments/assets/643ddd0f-8345-45b0-bc1b-b7661204bb36">

현재 서버로부터 전달받는 거리는 미터 단위입니다. 이를 도보 거리로 변경하기 위한 로직은 Cell의 RenderObject가 보유하고 있습니다.
추후에 다른 곳에서 사용할 수 있는 경우 UseCase등으로 빼려고 합니다