### PR TITLE
[IDLE-000] 요양보호사 공고화면 세부 변경사항 반영

### DIFF
--- a/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/AppliedAndLikedBoardCoordinator.swift
+++ b/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/AppliedAndLikedBoardCoordinator.swift
@@ -74,7 +74,8 @@ extension AppliedAndLikedBoardCoordinator {
                 parent: self,
                 navigationController: navigationController,
                 recruitmentPostUseCase: injector.resolve(RecruitmentPostUseCase.self),
-                workerProfileUseCase: injector.resolve(WorkerProfileUseCase.self)
+                workerProfileUseCase: injector.resolve(WorkerProfileUseCase.self),
+                centerProfileUseCase: injector.resolve(CenterProfileUseCase.self)
             )
         )
         addChildCoordinator(coodinator)

--- a/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/AppliedAndLikedBoardCoordinator.swift
+++ b/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/AppliedAndLikedBoardCoordinator.swift
@@ -92,4 +92,6 @@ extension AppliedAndLikedBoardCoordinator {
         coordinator.parent = self
         coordinator.start()
     }
+    
+    func showWorkerProfile() { }
 }

--- a/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/WorkerRecruitmentBoardCoordinator.swift
+++ b/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/WorkerRecruitmentBoardCoordinator.swift
@@ -63,7 +63,8 @@ extension WorkerRecruitmentBoardCoordinator {
                 parent: self,
                 navigationController: navigationController,
                 recruitmentPostUseCase: injector.resolve(RecruitmentPostUseCase.self),
-                workerProfileUseCase: injector.resolve(WorkerProfileUseCase.self)
+                workerProfileUseCase: injector.resolve(WorkerProfileUseCase.self),
+                centerProfileUseCase: injector.resolve(CenterProfileUseCase.self)
             )
         )
         addChildCoordinator(coodinator)

--- a/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/WorkerRecruitmentBoardCoordinator.swift
+++ b/project/Projects/App/Sources/RootCoordinator/Main/Worker/SubCoordinator/WorkerRecruitmentBoardCoordinator.swift
@@ -81,5 +81,18 @@ extension WorkerRecruitmentBoardCoordinator {
         coordinator.parent = self
         coordinator.start()
     }
+    
+    public func showWorkerProfile() {
+        let coordinator = WorkerProfileCoordinator(
+            dependency: .init(
+                profileMode: .myProfile,
+                navigationController: navigationController,
+                workerProfileUseCase: injector.resolve(WorkerProfileUseCase.self)
+            )
+        )
+        addChildCoordinator(coordinator)
+        coordinator.parent = self
+        coordinator.start()
+    }
 }
 

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Button/PhoneCSButton.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Button/PhoneCSButton.swift
@@ -107,6 +107,16 @@ public class PhoneCSButton: TappableUIView {
         
         self.nameLabel.textString = nameText
         self.phoneNumberLabel.textString = phoneNumberText
+        
+        self
+            .rx.tap
+            .subscribe(onNext: {
+                
+                if let phoneURL = URL(string: "tel://\(phoneNumberText)"), UIApplication.shared.canOpenURL(phoneURL) {
+                            UIApplication.shared.open(phoneURL, options: [:], completionHandler: nil)
+                        }
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/Coordinator/PostDetailForWorkerCoodinator.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/Coordinator/PostDetailForWorkerCoodinator.swift
@@ -19,6 +19,7 @@ public class PostDetailForWorkerCoodinator: ChildCoordinator {
         let navigationController: UINavigationController
         let recruitmentPostUseCase: RecruitmentPostUseCase
         let workerProfileUseCase: WorkerProfileUseCase
+        let centerProfileUseCase: CenterProfileUseCase
         
         public init(
             postType: RecruitmentPostType,
@@ -26,7 +27,8 @@ public class PostDetailForWorkerCoodinator: ChildCoordinator {
             parent: WorkerRecruitmentBoardCoordinatable? = nil,
             navigationController: UINavigationController,
             recruitmentPostUseCase: RecruitmentPostUseCase,
-            workerProfileUseCase: WorkerProfileUseCase
+            workerProfileUseCase: WorkerProfileUseCase,
+            centerProfileUseCase: CenterProfileUseCase
         ) {
             self.postType = postType
             self.postId = postId
@@ -34,6 +36,7 @@ public class PostDetailForWorkerCoodinator: ChildCoordinator {
             self.navigationController = navigationController
             self.recruitmentPostUseCase = recruitmentPostUseCase
             self.workerProfileUseCase = workerProfileUseCase
+            self.centerProfileUseCase = centerProfileUseCase
         }
     }
     
@@ -45,6 +48,7 @@ public class PostDetailForWorkerCoodinator: ChildCoordinator {
     public let navigationController: UINavigationController
     let recruitmentPostUseCase: RecruitmentPostUseCase
     let workerProfileUseCase: WorkerProfileUseCase
+    let centerProfileUseCase: CenterProfileUseCase
     
     public init(
         dependency: Dependency
@@ -55,6 +59,7 @@ public class PostDetailForWorkerCoodinator: ChildCoordinator {
         self.navigationController = dependency.navigationController
         self.recruitmentPostUseCase = dependency.recruitmentPostUseCase
         self.workerProfileUseCase = dependency.workerProfileUseCase
+        self.centerProfileUseCase = dependency.centerProfileUseCase
     }
     
     deinit {
@@ -72,7 +77,8 @@ public class PostDetailForWorkerCoodinator: ChildCoordinator {
                 postId: postId,
                 coordinator: self,
                 recruitmentPostUseCase: recruitmentPostUseCase, 
-                workerProfileUseCase: workerProfileUseCase
+                workerProfileUseCase: workerProfileUseCase,
+                centerProfileUseCase: centerProfileUseCase
             )
             nativeDetailVC.bind(viewModel: vm)
             vc = nativeDetailVC

--- a/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/View/Postdetail/NativePostDetailForWorkerVC.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/View/Postdetail/NativePostDetailForWorkerVC.swift
@@ -203,10 +203,12 @@ public class NativePostDetailForWorkerVC: BaseViewController {
             })
             .disposed(by: disposeBag)
         
+        // 지원성공시 비활성화
         viewModel
-            .alertDriver?
-            .drive(onNext: { [weak self] alertVO in
-                self?.showAlert(vo: alertVO)
+            .applySuccess?
+            .drive(onNext: { [weak self] in
+                guard let self else { return }
+                self.applyButton.setEnabled(false)
             })
             .disposed(by: disposeBag)
         

--- a/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/View/Postdetail/NativePostDetailForWorkerVC.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/View/Postdetail/NativePostDetailForWorkerVC.swift
@@ -35,6 +35,7 @@ public class NativePostDetailForWorkerVC: BaseViewController {
     let applyButton: IdlePrimaryButton = {
         let btn = IdlePrimaryButton(level: .medium)
         btn.label.textString = "지원하기"
+        btn.setEnabled(false)
         return btn
     }()
     
@@ -110,8 +111,6 @@ public class NativePostDetailForWorkerVC: BaseViewController {
         super.bind(viewModel: viewModel)
         
         // Output
-        let centerPhoneNumber: PublishSubject<String> = .init()
-        
         viewModel
             .postForWorkerBundle?
             .drive(onNext: {
@@ -123,6 +122,14 @@ public class NativePostDetailForWorkerVC: BaseViewController {
                 let cardRO: WorkerNativeEmployCardRO = .create(vo: cardVO)
                 
                 contentView.cardView.bind(ro: cardRO)
+                
+                if bundle.applyDate != nil {
+                    // 지원한 공고인 경우
+                    applyButton.setEnabled(false)
+                } else {
+                    // 지원하지 않은 공고인 경우
+                    applyButton.setEnabled(true)
+                }
                 
                 // 근무 조건
                 contentView.workConditionView.bind(

--- a/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/View/SelectCSTypeVC.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/View/View/RecruitmentPost/Worker/Detail/View/SelectCSTypeVC.swift
@@ -12,21 +12,21 @@ import RxSwift
 import Entity
 import DSKit
 
-public class SelectCSTypeVC: IdleBottomSheetVC {
+class SelectCSTypeVC: IdleBottomSheetVC {
     
     // Init
     
     // View
     let phoneCSButton: PhoneCSButton = .init()
     
-    public override init() {
+    override init() {
         super.init()
         setObservable()
     }
     
-    public required init?(coder: NSCoder) { fatalError() }
+    required init?(coder: NSCoder) { fatalError() }
     
-    public override func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
         
         setLayout()
@@ -51,7 +51,6 @@ public class SelectCSTypeVC: IdleBottomSheetVC {
     private func setObservable() {
         
     }
-    
 }
 
 @available(iOS 17.0, *)

--- a/project/Projects/Presentation/Feature/Base/Sources/ViewModelType/BaseViewModel.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/ViewModelType/BaseViewModel.swift
@@ -77,6 +77,7 @@ open class BaseViewModel {
     public func mapStartLoading<T>(_ target: Observable<T>) -> Observable<T> {
         
         target
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .map { [weak self] item in
                 
                 self?.showLoading.onNext(())

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/RecruitmentPost/OnGoingPostBoard/WorkerBoardEmptyView.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/RecruitmentPost/OnGoingPostBoard/WorkerBoardEmptyView.swift
@@ -1,0 +1,71 @@
+//
+//  WorkerBoardEmptyView.swift
+//  WorkerFeature
+//
+//  Created by choijunios on 9/12/24.
+//
+
+import UIKit
+import DSKit
+
+import RxSwift
+import RxCocoa
+
+class WorkerBoardEmptyView: UIView {
+    
+    let titleLabel: IdleLabel = {
+        let label = IdleLabel(typography: .Heading2)
+        label.textString = "아직 해당 지역의 공고가 없어요."
+        label.textAlignment = .center
+        return label
+    }()
+    
+    let descriptionLabel: IdleLabel = {
+        let label = IdleLabel(typography: .Body3)
+        label.attrTextColor = DSColor.gray300.color
+        label.numberOfLines = 3
+        label.textString = "나의 위치를 근처 다른 지역으로 바꿔\n새로운 공고를 탐색해보세요.\n나의 위치는 추후에 다시 변경할 수 있어요."
+        label.textAlignment = .center
+        return label
+    }()
+    
+    let editProfile: IdleThirdinaryButton = {
+        let button = IdleThirdinaryButton(level: .medium)
+        button.label.textString = "내 프로필 수정"
+        return button
+    }()
+    
+    init() {
+        super.init(frame: .zero)
+        
+        setAppearance()
+        setLayout()
+    }
+    required init?(coder: NSCoder) { nil }
+    
+    func setAppearance() {
+        self.backgroundColor = .clear
+    }
+    
+    func setLayout() {
+        
+        let mainStack = VStack([
+            titleLabel,
+            Spacer(height: 8),
+            descriptionLabel,
+            Spacer(height: 20),
+            editProfile,
+        ])
+        
+        self.addSubview(mainStack)
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            
+            editProfile.widthAnchor.constraint(equalToConstant: 165),
+            
+            mainStack.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            mainStack.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+        ])
+    }
+}

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVC.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVC.swift
@@ -68,6 +68,7 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
                 guard let self else { return }
                 
                 self.postData = postData
+                
                 postTableView.reloadData()
                 isPaging = false
                 
@@ -76,6 +77,13 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
                         self?.postTableView.setContentOffset(.zero, animated: false)
                     }
                 }
+                
+                postTableView.layoutIfNeeded()
+                if self.checkScrollViewHasSpace() {
+                    // 빈공간이 있는 경우 바로 다음요청
+                    requestNextPage.accept(())
+                }
+                
                 
                 // 공고가 없을 경우
                 emptyScreen.isHidden = (postData.count != 0)
@@ -159,6 +167,10 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
     
     private func setObservable() {
         
+    }
+    
+    func checkScrollViewHasSpace() -> Bool {
+        postTableView.contentSize.height < postTableView.frame.height
     }
 }
 

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVC.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVC.swift
@@ -25,6 +25,11 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
     }()
     let postTableView = UITableView()
     let tableHeader = BoardSortigHeaderView()
+    let emptyScreen: WorkerBoardEmptyView = {
+        let view = WorkerBoardEmptyView()
+        view.isHidden = true
+        return view
+    }()
     
     // Paging
     var isPaging = true
@@ -61,6 +66,7 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
             .postBoardData?
             .drive(onNext: { [weak self] (isRefreshed: Bool, postData) in
                 guard let self else { return }
+                
                 self.postData = postData
                 postTableView.reloadData()
                 isPaging = false
@@ -70,6 +76,9 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
                         self?.postTableView.setContentOffset(.zero, animated: false)
                     }
                 }
+                
+                // 공고가 없을 경우
+                emptyScreen.isHidden = (postData.count != 0)
             })
             .disposed(by: disposeBag)
         
@@ -119,7 +128,8 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
         
         [
             topContainer,
-            postTableView
+            postTableView,
+            emptyScreen,
         ].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview($0)
@@ -127,13 +137,18 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
         
         NSLayoutConstraint.activate([
             topContainer.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            topContainer.leftAnchor.constraint(equalTo: view.leftAnchor),
-            topContainer.rightAnchor.constraint(equalTo: view.rightAnchor),
+            topContainer.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor),
+            topContainer.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor),
             
             postTableView.topAnchor.constraint(equalTo: topContainer.bottomAnchor),
-            postTableView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            postTableView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            postTableView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor),
+            postTableView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor),
             postTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            emptyScreen.topAnchor.constraint(equalTo: topContainer.bottomAnchor),
+            emptyScreen.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor),
+            emptyScreen.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor),
+            emptyScreen.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }
     

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVC.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVC.swift
@@ -90,6 +90,11 @@ public class WorkerRecruitmentPostBoardVC: BaseViewController {
             .disposed(by: disposeBag)
         
         // Input
+        self.emptyScreen
+            .editProfile.rx.tap
+            .bind(to: viewModel.editProfileButtonClicked)
+            .disposed(by: disposeBag)
+        
         self.rx.viewDidLoad
             .bind(to: viewModel.requestWorkerLocation)
             .disposed(by: disposeBag)

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVM.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/RecruitmentPost/OnGoingPostBoard/WorkerRecruitmentPostBoardVM.swift
@@ -45,6 +45,9 @@ public protocol WorkerRecruitmentPostBoardVMable: WorkerAppliablePostBoardVMable
     /// 요양보호사 위치정보를 요청합니다.
     var requestWorkerLocation: PublishRelay<Void> { get }
     
+    /// 프로필 수정버튼이 눌린 경우
+    var editProfileButtonClicked: PublishRelay<Void> { get }
+    
     /// 요양보호사 위치 정보를 전달합니다.
     var workerLocationTitleText: Driver<String>? { get }
 }
@@ -56,7 +59,9 @@ public class WorkerRecruitmentPostBoardVM: BaseViewModel, WorkerRecruitmentPostB
     public var workerLocationTitleText: Driver<String>?
     public var idleAlertVM: RxCocoa.Driver<any DSKit.IdleAlertViewModelable>?
     
+    
     // Input
+    public var editProfileButtonClicked: PublishRelay<Void> = .init()
     public var requestInitialPageRequest: PublishRelay<Void> = .init()
     public var requestWorkerLocation: PublishRelay<Void> = .init()
     public var requestNextPage: PublishRelay<Void> = .init()
@@ -266,6 +271,15 @@ public class WorkerRecruitmentPostBoardVM: BaseViewModel, WorkerRecruitmentPostB
                     message: error.message
                 )
             }
+        
+        // MARK: 프로필 수정
+        editProfileButtonClicked
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.coordinator?.showWorkerProfile()
+            })
+            .disposed(by: dispostBag)
         
         Observable
             .merge(

--- a/project/Projects/Presentation/PresentationCore/Sources/ScreenCoordinating/Interface/RecruitmentPost/Worker/WorkerRecruitmentBoardCoordinatable.swift
+++ b/project/Projects/Presentation/PresentationCore/Sources/ScreenCoordinating/Interface/RecruitmentPost/Worker/WorkerRecruitmentBoardCoordinatable.swift
@@ -14,4 +14,7 @@ public protocol WorkerRecruitmentBoardCoordinatable: ParentCoordinator {
     
     /// 센터 프로필을 표시합니다.
     func showCenterProfile(centerId: String)
+    
+    /// 요양보호사의 프로필을 표시합니다.
+    func showWorkerProfile()
 }


### PR DESCRIPTION
## 변경된점

- 스낵바 적용
- 문의하기 버튼 클릭시 전화앱으로 연결
- 공고목록 조회 조건 수정

### 공고목록 조회 조건 수정

수정전의 경우 새로운 공고리스트를 조회하기 위해선 반드시 스크롤을 해야 했습니다.
하지만, 처음으로 불러온 공고의 개수가 화면을 가득 채우지 않는다면, 스크롤이 굳이 필요하지 않다고 생각했습니다.
공고를 불러온 경우
layoutIfNeeded로 즉시 셀의 레이아웃을 계산하고, 여백이 존재하는 경우 즉시 새로운 공고리스트를 가져오도록 변경했습니다.

데이터를 불러온 경우 호출되는 함수
<img width="635" alt="스크린샷 2024-09-13 오전 12 41 20" src="https://github.com/user-attachments/assets/349e58bf-1d25-4adf-a58e-6aa554320840">
