### PR TITLE
[IDLE-000] 이미지 로딩 최적화

### DIFF
--- a/project/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency.swift
+++ b/project/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency.swift
@@ -53,6 +53,7 @@ public extension ModuleDependency {
         public static let FirebaseCrashlytics: TargetDependency = .external(name: "FirebaseCrashlytics")
         public static let FirebaseAnalytics: TargetDependency = .external(name: "FirebaseAnalytics")
         public static let Amplitude: TargetDependency = .external(name: "AmplitudeSwift")
+        public static let SDWebImageWebPCoder: TargetDependency = .external(name: "SDWebImageWebPCoder")
     }
 }
 

--- a/project/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency.swift
+++ b/project/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Dependency.swift
@@ -48,7 +48,6 @@ public extension ModuleDependency {
         public static let RxMoya: TargetDependency = .external(name: "RxMoya")
         public static let FSCalendar: TargetDependency = .external(name: "FSCalendar")
         public static let NaverMapSDKForSPM: TargetDependency = .external(name: "Junios.NMapSDKForSPM")
-        public static let KingFisher: TargetDependency = .external(name: "Kingfisher")
         public static let FirebaseRemoteConfig: TargetDependency = .external(name: "FirebaseRemoteConfig")
         public static let FirebaseCrashlytics: TargetDependency = .external(name: "FirebaseCrashlytics")
         public static let FirebaseAnalytics: TargetDependency = .external(name: "FirebaseAnalytics")

--- a/project/Projects/App/Sources/DI/Assembly/DataAssembly.swift
+++ b/project/Projects/App/Sources/DI/Assembly/DataAssembly.swift
@@ -25,6 +25,7 @@ public struct DataAssembly: Assembly {
         container.register(CacheRepository.self) { _ in
             return DefaultCacheRepository()
         }
+        .inObjectScope(.container)
         
         // MARK: 로컬에 저장된 유저정보 레포지토리
         container.register(UserInfoLocalRepository.self) { resolver in

--- a/project/Projects/App/Sources/DI/Assembly/DataAssembly.swift
+++ b/project/Projects/App/Sources/DI/Assembly/DataAssembly.swift
@@ -21,6 +21,11 @@ public struct DataAssembly: Assembly {
             return DefaultLocalStorageService()
         }
         
+        // MARK: 캐싱 레포지토리
+        container.register(CacheRepository.self) { _ in
+            return DefaultCacheRepository()
+        }
+        
         // MARK: 로컬에 저장된 유저정보 레포지토리
         container.register(UserInfoLocalRepository.self) { resolver in
             let localStorageService = resolver.resolve(LocalStorageService.self)!

--- a/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
@@ -1,0 +1,319 @@
+//
+//  CacheRepository.swift
+//  ConcreteRepository
+//
+//  Created by choijunios on 9/21/24.
+//
+
+import Foundation
+import Entity
+import UIKit
+import UniformTypeIdentifiers
+
+import SDWebImageWebPCoder
+import RxSwift
+
+public class CachedImageObject {
+    
+    let downloadInfo: ImageDownLoadInfo
+    let data: Data
+    
+    public init(downloadInfo: ImageDownLoadInfo, data: Data) {
+        self.downloadInfo = downloadInfo
+        self.data = data
+    }
+}
+
+public protocol CacheRepository {
+    
+    /// 이미지 데이터를 획득합니다.
+    func getImage(imageInfo: ImageDownLoadInfo) -> Single<UIImage>
+}
+
+struct ImageCacheInfo: Codable {
+    let url: String
+    let format: ImageFormat
+    let date: Date
+    
+    func updateDate() -> Self {
+        .init(
+            url: url,
+            format: format,
+            date: .now
+        )
+    }
+}
+
+public class DefaultCacheRepository: CacheRepository {
+    
+    /// UserDefaults에 사여용되는 키
+    enum Key {
+        static let cacheInfoDict = "cacheInfoDictionary"
+    }
+    
+    /// 이미지를 메모리에서 캐싱하는 NSCache입니다.
+    private let imageMemoryCache: NSCache<NSString, UIImage> = .init()
+    
+    /// 캐시정보를 저장하는 딕셔너리입니다. 키: url , 값: (disk path, time)
+    private var cacheInfoDict: [String: ImageCacheInfo] {
+        if let dict = UserDefaults.standard.dictionary(forKey: Key.cacheInfoDict) {
+            
+            return dict.mapValues { value in
+                let data = value as! Data
+                let decoded = try! jsonDecoder.decode(ImageCacheInfo.self, from: data)
+                return decoded
+            }
+        }
+        let newDict: [String: Data] = [:]
+        UserDefaults.standard.set(newDict, forKey: Key.cacheInfoDict)
+        return [:]
+    }
+    
+    private let jsonDecoder = JSONDecoder()
+    private let jsonEncoder = JSONEncoder()
+    
+    public init() {
+        // 이미지 인메모리 캐시 설정
+        imageMemoryCache.countLimit = 30
+        imageMemoryCache.totalCostLimit = 20
+    }
+    
+    public func getImage(imageInfo: ImageDownLoadInfo) -> Single<UIImage> {
+        
+        Single<UIImage>.create { [weak self] observer in
+            
+            let urlString = imageInfo.imageURL.absoluteString
+            let cacheInfoKey = urlString
+            let memoryKey = NSString(string: urlString)
+            
+            // MARK: 메모리 캐싱정보 체크
+            if let image = self?.imageMemoryCache.object(forKey: memoryKey) {
+                
+                #if DEBUG
+                print("key: \(cacheInfoKey) memory cache hit")
+                #endif
+                
+                // 접근시간 업데이트
+                self?.updateLastReadTime(cacheInfoKey: cacheInfoKey)
+                
+                observer(.success(image))
+                
+            } else {
+                
+                // MARK: 디스크 캐싱정보 체크
+                if let image = self?.checkDiskCache(info: imageInfo) {
+                    
+                    #if DEBUG
+                    print("key: \(cacheInfoKey) disk cache hit")
+                    #endif
+                    
+                    // 접근시간 업데이트
+                    self?.updateLastReadTime(cacheInfoKey: cacheInfoKey)
+                    
+                    observer(.success(image))
+                    
+                } else {
+                    
+                    // 디스크정보 없음, 이미지 다운로드 실행
+                    do {
+                        let contents = try Data(contentsOf: imageInfo.imageURL)
+                        
+                        // 디스크에 파일 생성
+                        self?.createImageFile(imageURL: imageInfo.imageURL, contents: contents)
+                        
+                        // UIImage생성
+                        if let image = self?.createImage(data: contents, format: imageInfo.imageFormat) {
+                            
+                            // 캐싱정보 지정
+                            let cacheInfo = ImageCacheInfo(
+                                url: imageInfo.imageURL.absoluteString,
+                                format: imageInfo.imageFormat,
+                                date: .now
+                            )
+                            
+                            if var dict = self?.cacheInfoDict {
+                                dict[cacheInfoKey] = cacheInfo
+                                self?.setCacheInfoDict(dict: dict)
+                            }
+                            
+                            // 메모리 캐시에 올리기
+                            self?.imageMemoryCache.setObject(image, forKey: memoryKey)
+                            
+                            observer(.success(image))
+                        }
+                    } catch {
+                        #if DEBUG
+                        print("이미지 다운로드 싪패")
+                        #endif
+                    }
+                }
+            }
+            
+            return Disposables.create { }
+        }
+    }
+}
+
+// MARK: Cache info
+extension DefaultCacheRepository {
+    
+    var getCurrentTime: String {
+        let dateFormatter = ISO8601DateFormatter()
+        return dateFormatter.string(from: .now)
+    }
+    
+    /// 마지막으로 캐시를 읽은 시각 업데이트
+    func updateLastReadTime(cacheInfoKey: String) {
+        if let cacheInfo = cacheInfoDict[cacheInfoKey] {
+            let updated = cacheInfo.updateDate()
+            updateCacheInfoDict(key: cacheInfoKey, update: updated)
+            
+            #if DEBUG
+            print("key: \(cacheInfoKey) Hit time updated")
+            #endif
+        }
+    }
+    
+    /// 업데이트된 캐시정보를 저장합니다.
+    func updateCacheInfoDict(key: String, update: ImageCacheInfo) {
+        var dict = cacheInfoDict
+        dict[key] = update
+        setCacheInfoDict(dict: dict)
+    }
+    
+    func setCacheInfoDict(dict: [String: ImageCacheInfo]) {
+        let encoded = dict.mapValues { info in
+            try! jsonEncoder.encode(info)
+        }
+        UserDefaults.standard.set(encoded, forKey: Key.cacheInfoDict)
+    }
+}
+
+// MARK: Checking disk
+extension DefaultCacheRepository {
+    
+    /// image경로를 획득합니다.
+    func createImagePath(url: String) -> URL? {
+        
+        guard let path = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            #if DEBUG
+            print("\(url) 이미지 경로 생성 실패")
+            #endif
+            return nil
+        }
+        
+        let imageDirectory = path.appendingPathComponent("Image")
+        try? FileManager.default.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
+        
+        let imageFileName = url
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+        
+        let imageURL = imageDirectory
+            .appendingPathComponent(imageFileName)
+        return imageURL
+    }
+    
+    /// 디스크 캐시를 확인합니다.
+    func checkDiskCache(info: ImageDownLoadInfo) -> UIImage? {
+        
+        guard let imagePath = createImagePath(url: info.imageURL.absoluteString) else {
+            return nil
+        }
+        
+        if FileManager.default.fileExists(atPath: imagePath.path) {
+            
+            // 이미지 파일이 존재
+            
+            #if DEBUG
+            print("\(info.imageURL) : 파일이 존재함, 디스크 히트")
+            #endif
+            
+            // 접근시간 업데이트
+            updateLastReadTime(cacheInfoKey: info.imageURL.absoluteString)
+            
+            if let data = FileManager.default.contents(atPath: imagePath.path) {
+                
+                return createImage(data: data, format: info.imageFormat)
+            }
+            
+            #if DEBUG
+            print("\(info.imageURL) : 파일이 존재하지만 데이터를 불러오지 못함")
+            #endif
+            
+            return nil
+            
+        } else {
+            
+            // 파일이 존재하지 않는 경우
+            #if DEBUG
+            print("디스크에 파일이 존재하지 않음")
+            #endif
+            
+            return nil
+        }
+    }
+    
+    func createImageFile(imageURL: URL, contents: Data) {
+        
+        guard let imagePath = createImagePath(url: imageURL.absoluteString) else {
+            return
+        }
+        
+        let imageDirectoryPath = imagePath.deletingLastPathComponent()
+        
+        if let numOfFiles = try? FileManager.default.contentsOfDirectory(atPath: imageDirectoryPath.path).count {
+            
+            // 최대 파일수를 초과한 경우 삭제(LRU), 하위 10개 파일 삭제
+            if numOfFiles >= 50 {
+                
+                var dict = cacheInfoDict
+                let sortedInfo = dict.sorted { (lhs, rhs) in
+                    lhs.value.date < rhs.value.date
+                }
+                
+                // 이미지 파일 삭제
+                sortedInfo[0..<10].forEach { (key, value) in
+                    dict.removeValue(forKey: key)
+                    if let path = createImagePath(url: value.url) {
+                        do {
+                            try FileManager.default.removeItem(at: path)
+                        } catch {
+                            #if DEBUG
+                            print("\(imageURL) 이미지 삭제 실패")
+                            #endif
+                        }
+                    }
+                }
+                
+                // 이미지 캐싱정보 저장 (10개 삭제)
+                setCacheInfoDict(dict: dict)
+            }
+        }
+        
+        // 이미지 파일 생성
+        let fileCreationResult = FileManager.default.createFile(atPath: imagePath.path, contents: contents)
+        
+        #if DEBUG
+        print("디스크에 이미지 생성 \(fileCreationResult ? "성공" : "실패")")
+        #endif
+    }
+    
+    func createImage(data: Data, format: ImageFormat) -> UIImage? {
+        var image: UIImage?
+        if format == .webp {
+            image = SDImageWebPCoder.shared.decodedImage(with: data)
+        } else {
+            image = UIImage(data: data)
+        }
+        
+        if let image {
+            
+            return image
+        }
+        return nil
+        #if DEBUG
+        print("이미지 다운로드 싪패")
+        #endif
+    }
+}

--- a/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
@@ -9,20 +9,10 @@ import Foundation
 import Entity
 import UIKit
 import UniformTypeIdentifiers
+import RepositoryInterface
 
 import SDWebImageWebPCoder
 import RxSwift
-
-public class CachedImageObject {
-    
-    let downloadInfo: ImageDownLoadInfo
-    let data: Data
-    
-    public init(downloadInfo: ImageDownLoadInfo, data: Data) {
-        self.downloadInfo = downloadInfo
-        self.data = data
-    }
-}
 
 public protocol CacheRepository {
     
@@ -224,11 +214,8 @@ extension DefaultCacheRepository {
             // 이미지 파일이 존재
             
             #if DEBUG
-            print("\(info.imageURL) : 파일이 존재함, 디스크 히트")
+            print("\(info.imageURL) : 디스크에 파일이 존재함")
             #endif
-            
-            // 접근시간 업데이트
-            updateLastReadTime(cacheInfoKey: info.imageURL.absoluteString)
             
             if let data = FileManager.default.contents(atPath: imagePath.path) {
                 

--- a/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
@@ -100,6 +100,9 @@ public class DefaultCacheRepository: CacheRepository {
                     // 접근시간 업데이트
                     self?.updateLastReadTime(cacheInfoKey: cacheInfoKey)
                     
+                    // 메모리 캐시에 올리기
+                    self?.imageMemoryCache.setObject(image, forKey: memoryKey)
+                    
                     observer(.success(image))
                     
                 } else {

--- a/project/Projects/Data/ConcretesTests/ImageCachingTest.swift
+++ b/project/Projects/Data/ConcretesTests/ImageCachingTest.swift
@@ -1,0 +1,59 @@
+//
+//  ImageCachingTest.swift
+//  ConcretesTests
+//
+//  Created by choijunios on 9/22/24.
+//
+
+import Foundation
+import XCTest
+@testable import ConcreteRepository
+import Entity
+
+import RxSwift
+
+class ImageCachingTest: XCTestCase {
+    
+    let cacheRepo = DefaultCacheRepository()
+    let disposeBag = DisposeBag()
+    
+    func testCaching() {
+        
+        let imageInfo = ImageDownLoadInfo(
+            imageURL: URL(string: "https://fastly.picsum.photos/id/237/200/300.jpg?hmac=TmmQSbShHz9CdQm0NkEjx1Dyh_Y984R9LpNrpvH2D_U")!,
+            imageFormat: .jpeg
+        )
+        
+        let exp = XCTestExpectation(description: "caching")
+        cacheRepo
+            .getImage(imageInfo: imageInfo)
+            .map { image in
+                print("--첫번째 이미지--")
+            }
+            .flatMap { [cacheRepo]_ in
+                cacheRepo
+                    .getImage(imageInfo: imageInfo)
+            }
+            .map { image in
+                print("--메모리 캐싱 체크--")
+            }
+            .map { [cacheRepo]_ in
+                cacheRepo
+                    .checkDiskCache(info: imageInfo)
+            }
+            .subscribe(onSuccess: { image in
+                
+                print("--디스크 체크--")
+                
+                if let image {
+                    exp.fulfill()
+                } else {
+                    XCTFail()
+                }
+                
+            })
+            .disposed(by: disposeBag)
+        
+        wait(for: [exp], timeout: 5.0)
+    }
+}

--- a/project/Projects/Data/ConcretesTests/SaveUserInfoDataTests.swift
+++ b/project/Projects/Data/ConcretesTests/SaveUserInfoDataTests.swift
@@ -59,7 +59,7 @@ class SaveUserInfoDataTests: XCTestCase {
                 longitude: "test",
                 latitude: "test",
                 introduce: "test",
-                profileImageURL: nil
+                profileImageInfo: nil
             )
         )
         
@@ -82,7 +82,7 @@ class SaveUserInfoDataTests: XCTestCase {
         
         repository.updateCurrentWorkerData(
             vo: .init(
-                profileImageURL: nil,
+                profileImageInfo: nil,
                 nameText: "test",
                 phoneNumber: "test",
                 isLookingForJob: true,

--- a/project/Projects/Data/DataSource/DTO/RecruitmentPost/ApplicantList/PostApplicantDTO.swift
+++ b/project/Projects/Data/DataSource/DTO/RecruitmentPost/ApplicantList/PostApplicantDTO.swift
@@ -20,14 +20,24 @@ public struct PostApplicantDTO: Codable {
     
     public func toVO() -> PostApplicantVO {
         
-        var profileUrl: URL?
-        if let profileImageUrl {
-            profileUrl = URL(string: profileImageUrl)
+        var imageInfo: ImageDownLoadInfo? = nil
+        
+        if let url = profileImageUrl, let expString = url.split(separator: ".").last {
+            
+            let imageFormat = expString.uppercased()
+            
+            if let format = ImageFormat(rawValue: imageFormat) {
+                    
+                imageInfo = .init(
+                    imageURL: URL(string: url)!,
+                    imageFormat: format
+                )
+            }
         }
         
         return .init(
             workerId: carerId,
-            profileUrl: profileUrl,
+            imageInfo: imageInfo,
             isJobFinding: jobSearchStatus == "YES",
             
             // MARK:  센터가 즐겨찾기하는 요양보호사 추후 개발예정

--- a/project/Projects/Data/DataSource/DTO/UserInfo/CenterProfileDTO.swift
+++ b/project/Projects/Data/DataSource/DTO/UserInfo/CenterProfileDTO.swift
@@ -23,7 +23,23 @@ public struct CenterProfileDTO: Codable {
 public extension CenterProfileDTO {
     
     func toEntity() -> CenterProfileVO {
-        CenterProfileVO(
+        
+        var imageInfo: ImageDownLoadInfo? = nil
+        
+        if let url = profileImageUrl, let expString = url.split(separator: ".").last {
+            
+            let imageFormat = expString.uppercased()
+            
+            if let format = ImageFormat(rawValue: imageFormat) {
+                    
+                imageInfo = .init(
+                    imageURL: URL(string: url)!,
+                    imageFormat: format
+                )
+            }
+        }
+        
+        return .init(
             centerName: centerName,
             officeNumber: officeNumber,
             roadNameAddress: roadNameAddress,
@@ -32,7 +48,7 @@ public extension CenterProfileDTO {
             longitude: longitude ?? "",
             latitude: latitude ?? "",
             introduce: introduce ?? "",
-            profileImageURL: URL(string: profileImageUrl ?? "")
+            profileImageInfo: imageInfo
         )
     }
 }

--- a/project/Projects/Data/DataSource/DTO/UserInfo/WorkerProfileDTO.swift
+++ b/project/Projects/Data/DataSource/DTO/UserInfo/WorkerProfileDTO.swift
@@ -25,8 +25,23 @@ public struct CarerProfileDTO: Codable {
     
     public func toVO() -> WorkerProfileVO {
         
+        var imageInfo: ImageDownLoadInfo? = nil
+        
+        if let url = profileImageUrl, let expString = url.split(separator: ".").last {
+            
+            let imageFormat = expString.uppercased()
+            
+            if let format = ImageFormat(rawValue: imageFormat) {
+                    
+                imageInfo = .init(
+                    imageURL: URL(string: url)!,
+                    imageFormat: format
+                )
+            }
+        }
+        
         return .init(
-            profileImageURL: profileImageUrl,
+            profileImageInfo: imageInfo,
             nameText: carerName,
             phoneNumber: phoneNumber,
             isLookingForJob: jobSearchStatus == "YES",

--- a/project/Projects/Data/Project.swift
+++ b/project/Projects/Data/Project.swift
@@ -31,7 +31,8 @@ let project = Project(
                 
                 // ThirdParty
                 D.ThirdParty.RxSwift,
-                D.ThirdParty.FirebaseRemoteConfig
+                D.ThirdParty.FirebaseRemoteConfig,
+                D.ThirdParty.SDWebImageWebPCoder,
             ],
             settings: .settings(
                 base: ["ENABLE_TESTABILITY": "YES"]

--- a/project/Projects/Domain/Entity/Transport/ImageDownLoadInfo.swift
+++ b/project/Projects/Domain/Entity/Transport/ImageDownLoadInfo.swift
@@ -22,7 +22,6 @@ public struct ImageDownLoadInfo: Codable {
 }
 
 public enum ImageFormat: String, Codable, Equatable {
-    case jpg = "JPG"
     case jpeg = "JPEG"
     case png = "PNG"
     case gif = "GIF"

--- a/project/Projects/Domain/Entity/Transport/ImageDownLoadInfo.swift
+++ b/project/Projects/Domain/Entity/Transport/ImageDownLoadInfo.swift
@@ -1,0 +1,31 @@
+//
+//  ImageDownLoadInfo.swift
+//  Entity
+//
+//  Created by choijunios on 9/21/24.
+//
+
+import Foundation
+
+public struct ImageDownLoadInfo: Codable {
+    
+    public let imageURL: URL
+    public let imageFormat: ImageFormat
+    
+    public init(
+        imageURL: URL,
+        imageFormat: ImageFormat
+    ) {
+        self.imageURL = imageURL
+        self.imageFormat = imageFormat
+    }
+}
+
+public enum ImageFormat: String, Codable {
+    case jpg = "JPG"
+    case jpeg = "JPEG"
+    case png = "PNG"
+    case gif = "GIF"
+    case webp = "WEBP"
+//    case svg = "SVG"
+}

--- a/project/Projects/Domain/Entity/Transport/ImageDownLoadInfo.swift
+++ b/project/Projects/Domain/Entity/Transport/ImageDownLoadInfo.swift
@@ -21,7 +21,7 @@ public struct ImageDownLoadInfo: Codable {
     }
 }
 
-public enum ImageFormat: String, Codable {
+public enum ImageFormat: String, Codable, Equatable {
     case jpg = "JPG"
     case jpeg = "JPEG"
     case png = "PNG"

--- a/project/Projects/Domain/Entity/VO/Employ/PostApplicantVO.swift
+++ b/project/Projects/Domain/Entity/VO/Employ/PostApplicantVO.swift
@@ -15,7 +15,7 @@ public struct PostApplicantVO {
     public let workerId: String
     
     // For Render
-    public let profileUrl: URL?
+    public let imageInfo: ImageDownLoadInfo?
     public let isJobFinding: Bool
     public let isStared: Bool
     public let name: String
@@ -23,9 +23,9 @@ public struct PostApplicantVO {
     public let gender: Gender
     public let expYear: Int?
     
-    public init(workerId: String, profileUrl: URL?, isJobFinding: Bool, isStared: Bool, name: String, age: Int, gender: Gender, expYear: Int?) {
+    public init(workerId: String, imageInfo: ImageDownLoadInfo?, isJobFinding: Bool, isStared: Bool, name: String, age: Int, gender: Gender, expYear: Int?) {
         self.workerId = workerId
-        self.profileUrl = profileUrl
+        self.imageInfo = imageInfo
         self.isJobFinding = isJobFinding
         self.isStared = isStared
         self.name = name
@@ -36,7 +36,7 @@ public struct PostApplicantVO {
     
     public static let mock: PostApplicantVO = .init(
         workerId: "testworkerId",
-        profileUrl: URL(string: "https://dummyimage.com/600x400/00ffbf/0011ff&text=worker+profile"),
+        imageInfo: nil,
         isJobFinding: false,
         isStared: false,
         name: "홍길동",

--- a/project/Projects/Domain/Entity/VO/UserInfo/CenterProfileVO.swift
+++ b/project/Projects/Domain/Entity/VO/UserInfo/CenterProfileVO.swift
@@ -16,9 +16,9 @@ public class CenterProfileVO: Codable {
     public let longitude: String
     public let latitude: String
     public let introduce: String
-    public let profileImageURL: URL?
+    public let profileImageInfo: ImageDownLoadInfo?
     
-    public init(centerName: String, officeNumber: String, roadNameAddress: String, lotNumberAddress: String, detailedAddress: String, longitude: String, latitude: String, introduce: String, profileImageURL: URL?) {
+    public init(centerName: String, officeNumber: String, roadNameAddress: String, lotNumberAddress: String, detailedAddress: String, longitude: String, latitude: String, introduce: String, profileImageInfo: ImageDownLoadInfo?) {
         self.centerName = centerName
         self.officeNumber = officeNumber
         self.roadNameAddress = roadNameAddress
@@ -27,6 +27,6 @@ public class CenterProfileVO: Codable {
         self.longitude = longitude
         self.latitude = latitude
         self.introduce = introduce
-        self.profileImageURL = profileImageURL
+        self.profileImageInfo = profileImageInfo
     }
 }

--- a/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
+++ b/project/Projects/Domain/Entity/VO/UserInfo/WorkerProfileVO.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct WorkerProfileVO: Codable {
     
-    public let profileImageURL: String?
+    public let profileImageInfo: ImageDownLoadInfo?
     public let longitude: Double
     public let latitude: Double
     public let nameText: String
@@ -23,7 +23,7 @@ public struct WorkerProfileVO: Codable {
     public let specialty: String
     
     public init(
-        profileImageURL: String?,
+        profileImageInfo: ImageDownLoadInfo?,
         nameText: String,
         phoneNumber: String,
         isLookingForJob: Bool,
@@ -36,7 +36,7 @@ public struct WorkerProfileVO: Codable {
         longitude: Double,
         latitude: Double
     ) {
-        self.profileImageURL = profileImageURL
+        self.profileImageInfo = profileImageInfo
         self.nameText = nameText
         self.phoneNumber = phoneNumber
         self.isLookingForJob = isLookingForJob
@@ -53,7 +53,7 @@ public struct WorkerProfileVO: Codable {
 
 public extension WorkerProfileVO {
     static let mock: WorkerProfileVO = .init(
-        profileImageURL: nil,
+        profileImageInfo: nil,
         nameText: "",
         phoneNumber: "",
         isLookingForJob: true,

--- a/project/Projects/Presentation/DSKit/Project.swift
+++ b/project/Projects/Presentation/DSKit/Project.swift
@@ -32,7 +32,6 @@ let proejct = Project(
                 D.ThirdParty.RxSwift,
                 D.ThirdParty.RxCocoa,
                 D.ThirdParty.FSCalendar,
-                D.ThirdParty.KingFisher,
             ],
             settings: .settings(
                 configurations: IdleConfiguration.presentationConfigurations

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Card/Post/Worker/ApplyScreen/ApplicantCard.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Card/Post/Worker/ApplyScreen/ApplicantCard.swift
@@ -10,12 +10,10 @@ import PresentationCore
 import RxCocoa
 import RxSwift
 import Entity
-import Kingfisher
 import Entity
 
 public struct ApplicantCardRO {
     
-    public let profileUrl: URL?
     public let isJobFinding: Bool
 //    public let isStared: Bool
     public let name: String
@@ -24,7 +22,6 @@ public struct ApplicantCardRO {
     public let expText: String
     
     public init(
-        profileUrl: URL?,
         isJobFinding: Bool,
 //        isStared: Bool,
         name: String,
@@ -32,7 +29,6 @@ public struct ApplicantCardRO {
         genderText: String,
         expText: String
     ) {
-        self.profileUrl = profileUrl
         self.isJobFinding = isJobFinding
 //        self.isStared = isStared
         self.name = name
@@ -42,7 +38,6 @@ public struct ApplicantCardRO {
     }
     
     public static let mock: ApplicantCardRO = .init(
-        profileUrl: URL(string: "https://dummyimage.com/600x400/00ffbf/0011ff&text=worker+profile"),
         isJobFinding: false,
 //        isStared: false,
         name: "홍길동",
@@ -53,7 +48,6 @@ public struct ApplicantCardRO {
     
     public static func create(vo: PostApplicantVO) -> ApplicantCardRO {
         .init(
-            profileUrl: vo.profileUrl,
             isJobFinding: vo.isJobFinding,
 //            isStared: vo.isStared,
             name: vo.name,
@@ -73,6 +67,7 @@ public protocol ApplicantCardViewModelable {
     
     // Output
     var renderObject: Driver<ApplicantCardRO>? { get }
+    var displayingImage: Driver<UIImage>? { get }
 }
 
 public class ApplicantCard: UIView {
@@ -257,11 +252,6 @@ public class ApplicantCard: UIView {
     }
     
     public func bind(ro: ApplicantCardRO) {
-        
-        if let imageUrl = ro.profileUrl {
-            workerProfileImage
-                .setImage(url: imageUrl)
-        }
         
         workingTag.textString = ro.isJobFinding ? "구직중" : "휴식중"
 //        starButton.setState(ro.isStared ? .accent : .normal)

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/Card/Post/Worker/ApplyScreen/ApplicantCardCell.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/Card/Post/Worker/ApplyScreen/ApplicantCardCell.swift
@@ -69,6 +69,17 @@ public class ApplicantCardCell: UITableViewCell {
                 .drive(onNext: { [cardView] ro in
                     cardView.bind(ro: ro)
                 }),
+            
+            viewModel
+                .displayingImage?
+                .drive(onNext: { [weak self] image in
+                    
+                    guard let self else { return }
+                   
+                    UIView.transition(with: contentView, duration: 0.1) {
+                        self.cardView.workerProfileImage.image = image
+                    }
+                }),
    
             // Input
 //            cardView

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/ImageView/ImageSelectView.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/ImageView/ImageSelectView.swift
@@ -133,12 +133,12 @@ public class ImageSelectView: UIImageView {
                 displayingImage,
                 state
             )
-            .subscribe(onNext: { [weak self] (image, state) in
+            .asDriver(onErrorDriveWith: .never())
+            .drive(onNext: { [weak self] (image, state) in
                 
                 guard let self else { return }
                 
                 if image != nil {
-                    self.image = image
                     placeholderViewForEdit.isHidden = true
                     placeholderViewForNormal.isHidden = true
                     centerImageEditButton.isHidden = state == .normal

--- a/project/Projects/Presentation/DSKit/Sources/CommonUI/ImageView/ImageSelectView.swift
+++ b/project/Projects/Presentation/DSKit/Sources/CommonUI/ImageView/ImageSelectView.swift
@@ -139,6 +139,11 @@ public class ImageSelectView: UIImageView {
                 guard let self else { return }
                 
                 if image != nil {
+                    
+                    UIView.transition(with: self, duration: 0.2, options: .transitionCrossDissolve) {
+                        self.image = image
+                    }
+                    
                     placeholderViewForEdit.isHidden = true
                     placeholderViewForNormal.isHidden = true
                     centerImageEditButton.isHidden = state == .normal

--- a/project/Projects/Presentation/Feature/Auth/ExampleApp/Sources/SceneDelegate.swift
+++ b/project/Projects/Presentation/Feature/Auth/ExampleApp/Sources/SceneDelegate.swift
@@ -6,9 +6,6 @@
 //
 
 import UIKit
-import AuthFeature
-import BaseFeature
-import PresentationCore
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -17,18 +14,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         
         guard let windowScene = scene as? UIWindowScene else { return }
-        
-        let renderObject: AnonymousCompleteVCRenderObject = .init(
-            titleText: "센터관리자 로그인을\n완료했어요!",
-            descriptionText: "로그인 정보는 마지막 접속일부터\n180일간 유지될 예정이에요.",
-            completeButtonText: "시작하기") { }
-        
-        let vc = AnonymousCompleteVC()
-        vc.applyRO(renderObject)
+
         
         window = UIWindow(windowScene: windowScene)
         
-        window?.rootViewController = vc
+        
         window?.makeKeyAndVisible()
     }
 }

--- a/project/Projects/Presentation/Feature/Base/Project.swift
+++ b/project/Projects/Presentation/Feature/Base/Project.swift
@@ -34,6 +34,9 @@ let project = Project(
                 // Domain
                 D.Domain.UseCaseInterface,
                 D.Domain.RepositoryInterface,
+                
+                // Data
+                D.Data.ConcreteRepository,
 
                 // ThirdParty
                 D.ThirdParty.RxSwift,

--- a/project/Projects/Presentation/Feature/Base/Project.swift
+++ b/project/Projects/Presentation/Feature/Base/Project.swift
@@ -41,6 +41,7 @@ let project = Project(
                 D.ThirdParty.NaverMapSDKForSPM,
                 D.ThirdParty.FirebaseCrashlytics,
                 D.ThirdParty.FirebaseAnalytics,
+                D.ThirdParty.SDWebImageWebPCoder,
             ],
             settings: .settings(
                 configurations: IdleConfiguration.presentationConfigurations

--- a/project/Projects/Presentation/Feature/Base/Sources/Util/ImageUploadInfo+Extension.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/Util/ImageUploadInfo+Extension.swift
@@ -1,0 +1,39 @@
+//
+//  asd.swift
+//  BaseFeature
+//
+//  Created by choijunios on 9/21/24.
+//
+
+import Foundation
+import SDWebImageWebPCoder
+import Entity
+
+public extension ImageUploadInfo {
+    
+    private static let coder = {
+        let WebPCoder = SDImageWebPCoder.shared
+        SDImageCodersManager.shared.addCoder(WebPCoder)
+        return SDImageCodersManager.shared
+    }()
+    
+    static func create(image: UIImage) -> Self? {
+        
+        if let webpData = coder.encodedData(with: image, format: .webP) {
+            return .init(
+                data: webpData,
+                ext: "WEBP"
+            )
+        }
+        
+        if let pngData = image.pngData() {
+            return .init(data: pngData, ext: "PNG")
+        }
+        
+        if let jpegData = image.jpegData(compressionQuality: 1) {
+            return .init(data: jpegData, ext: "JPEG")
+        }
+        
+        return nil
+    }
+}

--- a/project/Projects/Presentation/Feature/Base/Sources/Util/UIImage+Extension.swift
+++ b/project/Projects/Presentation/Feature/Base/Sources/Util/UIImage+Extension.swift
@@ -1,0 +1,30 @@
+//
+//  UIImage+Extension.swift
+//  BaseFeature
+//
+//  Created by choijunios on 9/21/24.
+//
+
+import UIKit
+import Entity
+import SDWebImageWebPCoder
+
+public extension UIImage {
+    
+    static func create(downloadInfo: ImageDownLoadInfo) -> UIImage? {
+        
+        if let data = try? Data(contentsOf: downloadInfo.imageURL) {
+            
+            if downloadInfo.imageFormat == .webp {
+                
+                // 넓이*3 * 높이*3 * 1byte
+                let limitBytes = 320 * 250 * 9
+                let image = SDImageWebPCoder.shared.decodedImage(with: data, options: [.decodeScaleDownLimitBytes: limitBytes])
+                
+                return image
+            }
+            return .init(data: data)
+        }
+        return nil
+    }
+}

--- a/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
@@ -7,11 +7,13 @@
 
 import UIKit
 import Entity
-import RxSwift
-import RxCocoa
 import PresentationCore
 import UseCaseInterface
 import BaseFeature
+
+
+import RxSwift
+import RxCocoa
 import SDWebImageWebPCoder
 
 struct ChangeCenterInformation {
@@ -59,7 +61,6 @@ public class CenterProfileViewModel: BaseViewModel, CenterProfileViewModelable {
     private var fetchedImage: UIImage?
     
     private var editingImageInfo: ImageUploadInfo?
-    
     
     public var readyToFetch: PublishRelay<Void> = .init()
     public var editingButtonPressed: PublishRelay<Void> = .init()
@@ -161,22 +162,8 @@ public class CenterProfileViewModel: BaseViewModel, CenterProfileViewModelable {
         let fetchCenterImageInfo = profileRequestSuccess
             .compactMap { $0.profileImageInfo }
             .observe(on: imageDownLoadScheduler)
-            .map { downloadInfo -> UIImage? in
-                
-                if let data = try? Data(contentsOf: downloadInfo.imageURL) {
-                    
-                    if downloadInfo.imageFormat == .webp {
-
-                        // 넓이*3 * 높이*3 * 1byte
-                        let limitBytes = 320 * 250 * 9
-                        let image = SDImageWebPCoder.shared.decodedImage(with: data, options: [.decodeScaleDownLimitBytes: limitBytes])
-                        
-                        return image
-                    }
-                    
-                    return UIImage(data: data)
-                }
-                return nil
+            .map { downloadInfo in
+                UIImage.create(downloadInfo: downloadInfo)
             }
         
         // MARK: image validation

--- a/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
@@ -9,6 +9,8 @@ import UIKit
 import Entity
 import PresentationCore
 import UseCaseInterface
+import RepositoryInterface
+import ConcreteRepository
 import BaseFeature
 
 
@@ -51,6 +53,8 @@ public protocol CenterProfileOutputable {
 
 public class CenterProfileViewModel: BaseViewModel, CenterProfileViewModelable {
     
+    @Injected var cacheRepository: CacheRepository
+     
     let profileUseCase: CenterProfileUseCase
     weak var coordinator: CenterProfileCoordinator?
     
@@ -162,8 +166,11 @@ public class CenterProfileViewModel: BaseViewModel, CenterProfileViewModelable {
         let fetchCenterImageInfo = profileRequestSuccess
             .compactMap { $0.profileImageInfo }
             .observe(on: imageDownLoadScheduler)
-            .map { downloadInfo in
-                UIImage.create(downloadInfo: downloadInfo)
+            .flatMap { [cacheRepository] downloadInfo in
+                cacheRepository
+                    .getImage(imageInfo: downloadInfo)
+            }.map { image -> UIImage? in
+                image
             }
         
         // MARK: image validation

--- a/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
@@ -293,11 +293,6 @@ public class CenterProfileViewModel: BaseViewModel, CenterProfileViewModelable {
     }
     
     func validateSelectedImage(image: UIImage) -> ImageUploadInfo? {
-        if let pngData = image.pngData() {
-            return .init(data: pngData, ext: "PNG")
-        } else if let jpegData = image.jpegData(compressionQuality: 1) {
-            return .init(data: jpegData, ext: "JPEG")
-        }
-        return nil
+        .create(image: image)
     }
 }

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/Profile/EditWorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/Profile/EditWorkerProfileViewController.swift
@@ -410,9 +410,15 @@ public class EditWorkerProfileViewController: BaseViewController {
                 addressSearchButton.label.textString = ro.address
                 introductionInputField.textString = ro.oneLineIntroduce
                 abilityInputField.textString = ro.specialty
-                
-                if let imageUrl = ro.imageUrl {
-                    workerProfileImage.setImage(url: imageUrl)
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel
+            .displayingImage?
+            .drive(onNext: { [weak self] image in
+                guard let self else { return }
+                UIView.transition(with: view, duration: 0.2) {
+                    self.workerProfileImage .image = image
                 }
             })
             .disposed(by: disposeBag)

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/Profile/WorkerProfileViewController.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/Profile/WorkerProfileViewController.swift
@@ -479,11 +479,17 @@ public class WorkerProfileViewController: DisposableViewController {
                 expLabel.textString = ro.expText
                 
                 addressLabel.textString = ro.address
-                introductionLabel.textString = ro.oneLineIntroduce.emptyDefault("-")
-                abilityLabel.textString = ro.specialty.emptyDefault("-")
-                
-                if let imageUrl = ro.imageUrl {
-                    workerProfileImage.setImage(url: imageUrl)
+                introductionLabel.textString = ro.oneLineIntroduce
+                abilityLabel.textString = ro.specialty
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel
+            .displayingImage?
+            .drive(onNext: { [weak self] image in
+                guard let self else { return }
+                UIView.transition(with: view, duration: 0.2) {
+                    self.workerProfileImage .image = image
                 }
             })
             .disposed(by: disposeBag)

--- a/project/Projects/Presentation/Feature/Worker/Sources/View/RenderObject/WorkerProfileRenderObject.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/View/RenderObject/WorkerProfileRenderObject.swift
@@ -1,11 +1,11 @@
 //
-//  File.swift
+//  WorkerProfileRenderObject.swift
 //  WorkerFeature
 //
 //  Created by choijunios on 8/10/24.
 //
 
-import Foundation
+import UIKit
 import Entity
 
 // MARK: RO
@@ -25,11 +25,10 @@ public struct WorkerProfileRenderObject {
     let address: String
     let oneLineIntroduce: String
     let specialty: String
-    let imageUrl: URL?
     
     static func createRO(isMyProfile: Bool, vo: WorkerProfileVO) -> WorkerProfileRenderObject {
         
-        .init(
+        return .init(
             navigationTitle: isMyProfile ? "내 프로필" : "요양보호사 프로필",
             showEditButton: isMyProfile,
             showContactButton: !isMyProfile,
@@ -42,9 +41,9 @@ public struct WorkerProfileRenderObject {
             genderText: vo.gender.twoLetterKoreanWord,
             expText: vo.expYear == nil ? "신입" : "\(vo.expYear!)년차",
             address: vo.address.roadAddress,
-            oneLineIntroduce: vo.introductionText,
-            specialty: vo.specialty,
-            imageUrl: URL(string: vo.profileImageURL ?? "")
+            oneLineIntroduce: vo.introductionText.emptyDefault("-"),
+            specialty: vo.specialty
+                .emptyDefault("-")
         )
     }
 }

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/Profile/WorkerMyProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/Profile/WorkerMyProfileViewModel.swift
@@ -157,6 +157,7 @@ public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
                 self?.editingState.experienceYear = exp
             }
             .disposed(by: disposbag)
+
         
         editingAddress
             .subscribe(onNext: { [weak self] address in

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/Profile/WorkerMyProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/Profile/WorkerMyProfileViewModel.swift
@@ -11,6 +11,7 @@ import DSKit
 import Entity
 import UseCaseInterface
 import BaseFeature
+import ConcreteRepository
 
 
 import RxSwift
@@ -33,6 +34,8 @@ public protocol WorkerProfileEditViewModelable: WorkerProfileViewModelable {
 }
 
 public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
+    
+    @Injected var cacheRepository: CacheRepository
     
     public weak var coordinator: WorkerProfileCoordinator?
     
@@ -114,10 +117,13 @@ public class WorkerMyProfileViewModel: WorkerProfileEditViewModelable {
         displayingImage = fetchedProfileVOSuccess
             .compactMap { $0.profileImageInfo }
             .observe(on: imageDownLoadScheduler)
-            .map { downloadInfo in
-                UIImage.create(downloadInfo: downloadInfo)
-                
+            .flatMap { [cacheRepository] downloadInfo in
+                cacheRepository
+                    .getImage(imageInfo: downloadInfo)
             }
+            .map({ image -> UIImage? in
+                image
+            })
             .asDriver(onErrorJustReturn: nil)
         
         exitButtonClicked

--- a/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/Profile/WorkerProfileViewModelable.swift
+++ b/project/Projects/Presentation/Feature/Worker/Sources/ViewModel/Profile/WorkerProfileViewModelable.swift
@@ -20,5 +20,6 @@ public protocol WorkerProfileViewModelable {
     var exitButtonClicked: PublishRelay<Void> { get }
     
     // Output
+    var displayingImage: Driver<UIImage?>? { get }
     var profileRenderObject: Driver<WorkerProfileRenderObject>? { get }
 }

--- a/project/Tuist/Package.swift
+++ b/project/Tuist/Package.swift
@@ -55,6 +55,8 @@ let package = Package(
         .package(url: "https://github.com/J0onYEong/NaverMapSDKForSPM.git", from: "1.0.0"),
         // KingFisher
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.12.0"),
+        // WebpCoder
+        .package(url: "https://github.com/SDWebImage/SDWebImageWebPCoder.git", from: "0.14.6"),
         
         
         // MARK: Product logging

--- a/project/Tuist/Package.swift
+++ b/project/Tuist/Package.swift
@@ -53,8 +53,6 @@ let package = Package(
         .package(url: "https://github.com/WenchaoD/FSCalendar.git", from: "2.8.4"),
         // Naver map
         .package(url: "https://github.com/J0onYEong/NaverMapSDKForSPM.git", from: "1.0.0"),
-        // KingFisher
-        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.12.0"),
         // WebpCoder
         .package(url: "https://github.com/SDWebImage/SDWebImageWebPCoder.git", from: "0.14.6"),
         


### PR DESCRIPTION
## 변경된 점

- 이미지 업로드 시 이미지 파일 확장자 변경
- 이미지 캐싱추가

### 이미지 업로드 시 이미지 파일 확장자 변경

iOS의 경우 HEIC파일을 사용하여 이미지를 저장합니다. Android에서는 지원하지 않는 포맷으로 두 플랫폼이 공유할 수 있는 파일형식이 필요했습니다.
PNG의 경우 사진의 높은 해상도를 유지할 수 있지만 사진 한장의 용량이 20MB를 넘어 버리는 일이 종종 있었습니다. 이 경우 평균적으로 5초의 로딩 시간이 필요하였습니다.
WebP형식의 경우 PNG만큼 높은 화질을 유지할 수 있고 JPEG보다 압출률이 더 뛰어납니다(20~30%). 따라서 해당 파일 포맷을 채택하였습니다.
UIImage의 경우 기본적으로 WebP형식을 지원하지 않아 써드파티를 사용했습니다.

### 이미지 캐싱추가
이미지의 빠른 로딩을 위해 캐싱기능을 추가했습니다.
WebP를 지원하는 캐싱을 구현하기위해 직접 캐싱관리 객체를 구현하였습니다.
메모리 캐싱의 경우 **NSCache**를 사용했습니다.
디스크 캐싱의 경우 **FileManager**를 사용했습니다.
이미지 캐싱은 다음과 같은 과정으로 진행됩니다.
![image](https://github.com/user-attachments/assets/c5763bdc-5073-49f8-8dfd-9080c22e9cd8)

## 학습한점

### NSCache의 동작원리 NSString

NSCache는 Key, Value를 모두 클래스로 전달받는다. Key의 경우 강하게, Value의 경우 내부적으로 약하(weak)게 참조를 한다.
NSCache에 저장한 이후에도 해당 객체들에 대한 참조를 유지해야 NSCache에서 삭제되지 않는다.
외부 참조가 없을 경우 Key, Value쌍은 자동으로 삭제될 수 있다. (실제로 바로 삭제되진 않고 NSCache의 삭제대상이 된다.)
그리고 Key값비교는 참조비교를 통해 진행됨으로 인스턴스 내부 값이 같아도 다른 키로 인식된다.
이런 방식을 사용하는 이유는 메모리 관리를 원할하게 하기 위함이라고 한다.
`NSString`의 경우 **내용이 같으면 모든 인스턴스가 하나의 객체를 공유**한다.
특정 Key인스턴스를 여러곳에서 공유할 필요가 없음으로 Key값으로 사용하기 적절한 클래스이다. 