### PR TITLE
[IDLE-000] 이미지 캐싱 로직 수정

### DIFF
--- a/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
@@ -76,7 +76,9 @@ public class DefaultCacheRepository: CacheRepository {
         // MARK: 이미지 캐싱정보 확인
         let findCacheResult = findCache(imageInfo: imageInfo)
             .subscribe(on: fileManagerScheduler)
-            
+            .asObservable()
+            .share()
+        
         let cacheFound = findCacheResult.compactMap { $0 }
         let cacheNotFound = findCacheResult.filter { $0 == nil }
         
@@ -86,6 +88,7 @@ public class DefaultCacheRepository: CacheRepository {
             .map { [imageInfo] _ -> Data? in
                 try? Data(contentsOf: imageInfo.imageURL)
             }
+            .share()
         
         let downloadSuccess = imageDownloadResult.compactMap { $0 }
         
@@ -96,8 +99,6 @@ public class DefaultCacheRepository: CacheRepository {
                 
                 // 이미지 캐싱
                 self?.cacheImage(imageInfo: imageInfo, contents: data)
-                
-                print(Thread.current)
                 
                 return self?.createUIImage(data: data, format: imageInfo.imageFormat)
             }
@@ -114,8 +115,6 @@ public class DefaultCacheRepository: CacheRepository {
     private func findCache(imageInfo: ImageDownLoadInfo) -> Single<UIImage?> {
         
         Single<UIImage?>.create { [weak self] observer in
-
-            print(Thread.current)
             
             let urlString = imageInfo.imageURL.absoluteString
             let cacheInfoKey = urlString

--- a/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
@@ -62,10 +62,19 @@ public class DefaultCacheRepository: CacheRepository {
         return [:]
     }
     
+    /// 디스크캐시
+    let maxFileCount: Int
+    let removeFileCountForOveflow: Int
+    
     private let jsonDecoder = JSONDecoder()
     private let jsonEncoder = JSONEncoder()
     
-    public init() {
+    public init(maxFileCount: Int = 50, removeFileCountForOveflow: Int = 10) {
+        
+        // 디스크 캐싱 옵션 설정
+        self.maxFileCount = maxFileCount
+        self.removeFileCountForOveflow = removeFileCountForOveflow
+        
         // 이미지 인메모리 캐시 설정
         imageMemoryCache.countLimit = 30
         imageMemoryCache.totalCostLimit = 20
@@ -313,7 +322,7 @@ extension DefaultCacheRepository {
         if let numOfFiles = try? FileManager.default.contentsOfDirectory(atPath: imageDirectoryPath.path).count {
             
             // 최대 파일수를 초과한 경우 삭제(LRU), 하위 10개 파일 삭제
-            if numOfFiles >= 50 {
+            if numOfFiles >= maxFileCount {
                 #if DEBUG
                 print("디스크 파일수가 50개를 초과하였음 삭제실행")
                 #endif
@@ -324,7 +333,7 @@ extension DefaultCacheRepository {
                 }
                 
                 // 이미지 파일 삭제
-                sortedInfo[0..<10].forEach { (key, value) in
+                sortedInfo[0..<removeFileCountForOveflow].forEach { (key, value) in
                     dict.removeValue(forKey: key)
                     
                     if let path = createImagePath(url: value.url) {

--- a/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
+++ b/project/Projects/Data/ConcreteRepository/Cache/CacheRepository.swift
@@ -112,7 +112,7 @@ public class DefaultCacheRepository: CacheRepository {
     }
     
     
-    private func findCache(imageInfo: ImageDownLoadInfo) -> Single<UIImage?> {
+    func findCache(imageInfo: ImageDownLoadInfo) -> Single<UIImage?> {
         
         Single<UIImage?>.create { [weak self] observer in
             
@@ -159,7 +159,7 @@ public class DefaultCacheRepository: CacheRepository {
         }
     }
     
-    private func cacheImage(imageInfo: ImageDownLoadInfo, contents: Data) {
+    func cacheImage(imageInfo: ImageDownLoadInfo, contents: Data) -> Bool {
         
         // 디스크에 파일 생성
         createImageFile(imageURL: imageInfo.imageURL, contents: contents)
@@ -184,7 +184,13 @@ public class DefaultCacheRepository: CacheRepository {
             
             // 메모리 캐시에 올리기
             imageMemoryCache.setObject(image, forKey: memoryKey)
+            
+            // 캐싱 성공
+            return true
         }
+        
+        // 캐싱 실패
+        return false
     }
 }
 

--- a/project/Projects/Data/ConcretesTests/ImageCachingTest.swift
+++ b/project/Projects/Data/ConcretesTests/ImageCachingTest.swift
@@ -19,7 +19,7 @@ class ImageCachingTest: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        self.cacheRepository = .init()
+        self.cacheRepository = .init(maxFileCount: 5, removeFileCountForOveflow: 1)
         self.disposeBag = .init()
     }
     
@@ -39,7 +39,7 @@ class ImageCachingTest: XCTestCase {
         let counter = ImageFetchedCounter(count: 0)
         
         // 이미지 50개를 테스트
-        let observables = (0..<60).map { index in
+        let observables = (0..<10).map { index in
             
             let url = URL(string: "https://dummyimage.com/300x\(300+index)/000/fff")!
             let imageInfo = ImageDownLoadInfo(
@@ -61,7 +61,7 @@ class ImageCachingTest: XCTestCase {
                 counter.count += 1
                 print("이미지 획득 성공 \(counter.count)")
                 
-                if counter.count == 60 {
+                if counter.count == 10 {
                     
                     cacheExpectation.fulfill()
                 }
@@ -69,6 +69,6 @@ class ImageCachingTest: XCTestCase {
             .disposed(by: disposeBag)
             
         
-        wait(for: [cacheExpectation], timeout: 10.0)
+        wait(for: [cacheExpectation], timeout: 20.0)
     }
 }

--- a/project/Projects/Data/ConcretesTests/ImageCachingTest.swift
+++ b/project/Projects/Data/ConcretesTests/ImageCachingTest.swift
@@ -33,6 +33,12 @@ class ImageCachingTest: XCTestCase {
             }
         }
         
+        // 디스크 캐싱 내역 삭제
+        guard cacheRepository.clearImageCacheDirectory() else {
+            XCTFail("디스크 캐싱내역 삭제 실패")
+            return
+        }
+        
         let counter = ImageFetchedCounter(count: 0)
         
         // 이미지 50개를 테스트

--- a/project/Projects/Data/ConcretesTests/ImageCachingTest.swift
+++ b/project/Projects/Data/ConcretesTests/ImageCachingTest.swift
@@ -34,10 +34,7 @@ class ImageCachingTest: XCTestCase {
         }
         
         // 디스크 캐싱 내역 삭제
-        guard cacheRepository.clearImageCacheDirectory() else {
-            XCTFail("디스크 캐싱내역 삭제 실패")
-            return
-        }
+        _ = cacheRepository.clearImageCacheDirectory()
         
         let counter = ImageFetchedCounter(count: 0)
         

--- a/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
+++ b/project/Projects/Presentation/Feature/Center/Sources/ViewModel/Profile/CenterProfileViewModel.swift
@@ -127,6 +127,7 @@ public class CenterProfileViewModel: BaseViewModel, CenterProfileViewModelable {
         
         let profileRequestSuccess = profileRequestResult
             .compactMap { $0.value }
+            .share()
         
         let profileRequestFailure = profileRequestResult
             .compactMap { $0.error }


### PR DESCRIPTION
### 변경된점

- 이미지 캐싱로직 수정

### 이미지 캐싱로직 수정및 테스트 코드 작성

파일매니저를 여러 공간에서 동시에 접근할 시 동시성문제가 발생할 수 있습니다.
따라서 파일매니저에 접근하는 코드를 단일쓰레드에서 처리되도록 구현하였습니다.

이미지 캐싱은 다음과 같은 단계로 진행됩니다.

1. 메모리 및 디스크 캐싱확인 (직렬 스케줄려)
2. 캐시된 이미지가 없다면 다운로드 (동시 스케줄려)
3. 다운로드 완려된 이미지를 디스크및 메모리에 캐싱 (직렬 스케줄려)

이미지 다운로드 작업의 경우 여러곳에서 접근시 동시에 처리되도록 하기위해 아래코드처럼 각단계를 나누고 다른 스케줄러를 사용하도록 설계하였습니다.

```swift

// MARK: 이미지 캐싱정보 확인
let findCacheResult = findCache(imageInfo: imageInfo)
    .subscribe(on: fileManagerScheduler)
    .asObservable()
    .share()
let cacheFound = findCacheResult.compactMap { $0 }
let cacheNotFound = findCacheResult.filter { $0 == nil }
// MARK: 이미지 다운로드
let imageDownloadResult = cacheNotFound
    .observe(on: downloadScheduler)
    .map { [imageInfo] _ -> Data? in
        try? Data(contentsOf: imageInfo.imageURL)
    }
    .share()
let downloadSuccess = imageDownloadResult.compactMap { $0 }
// MARK: 다운로드된 이미지 캐싱
let downloadedImage = downloadSuccess
    .observe(on: fileManagerScheduler)
    .compactMap { [imageInfo, weak self] data -> UIImage? in
        
        // 이미지 캐싱
        _ = self?.cacheImage(imageInfo: imageInfo, contents: data)
        
        return self?.createUIImage(data: data, format: imageInfo.imageFormat)
    }
return Observable
    .merge(
        downloadedImage.asObservable(),
        cacheFound.asObservable()
    )
    .asSingle()

```

### 테스트 코드 작성

동시성 환경에 문제가 발생하는 지 확인하기 위해 60개의 이미지를 동시에 다운로드하는 테스트를 진행했습니다.

![스크린샷 2024-09-24 오후 1 16 01](https://github.com/user-attachments/assets/1799c119-4e2d-401e-9c8d-3d3a4f2c49d4)


CI 환경에서(Github action) 이미지 다운로드 속도가 너무 늦어, 테스트를 통과하지 못했지만 로컬에서 테스트가 통가된것을 확인하였습니다.
![스크린샷 2024-09-24 오후 2 04 09](https://github.com/user-attachments/assets/3e3e6075-ecb0-4055-8ce6-e80c099d5364)

